### PR TITLE
s/once is true/repeating is false/

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -44,7 +44,7 @@ We propose a new API which extends [Service Workers](https://github.com/slightly
                function() { // Failure
                  // If no SW registration
                  // User/UA denied permission
-                 // If once is true and interval is set
+                 // If repeating is false and interval is set
                });
       });
     </script>


### PR DESCRIPTION
The comments referenced a "once" property, but the example uses "repeating" instead. Updated the comment accordingly.
