### PR TITLE
Address feedback from Issue#161.

### DIFF
--- a/spec/PeriodicBackgroundSync-index.bs
+++ b/spec/PeriodicBackgroundSync-index.bs
@@ -5,29 +5,32 @@ ED: https://wicg.github.io/BackgroundSync/spec/PeriodicBackgroundSync-index.html
 Shortname: periodic-background-sync
 Level: 1
 Editor: Mugdha Lakhani, Google, nator@chromium.org
+Editor: Jake Archibald, Google, jakearchibald@chromium.org
 Abstract: This specification describes a method that enables web applications to periodically synchronize data and content in the background.
 Group: wicg
 Repository: WICG/BackgroundSync
+Markup Shorthands: css no, markdown yes
+Indent: 2
 </pre>
 
 <pre class="anchors">
 spec: background-fetch; urlPrefix: https://wicg.github.io/background-fetch/
-    type:interface; text: BackgroundFetchManager
-    type:dfn; text:background fetch
+  type:interface; text: BackgroundFetchManager
+  type:dfn; text:background fetch
 </pre>
 
 <pre class=link-defaults>
 spec:html; type:dfn; for:/; text:browsing context
 spec:service-workers;
-    type:dfn; text:frame type
-    type:dfn; text:origin
-    type:dfn; text:terminate service worker
-    type:dfn; for:/; text:service worker
+  type:dfn; text:frame type
+  type:dfn; text:origin
+  type:dfn; text:terminate service worker
+  type:dfn; for:/; text:service worker
 spec:web-background-sync;
-    type:dfn; text:online
-    type:dfn; text:in the background
+  type:dfn; text:online
 spec:permissions-1; type:dict-member; text:name
 spec:webidl; type:dfn; text:resolve
+spec:infra; type:dfn; text:list
 </pre>
 
 Introduction {#intro}
@@ -43,7 +46,7 @@ Introduction {#intro}
   As this API relies on service workers, functionality provided by this API is only available in a [=secure context=].
 
   ## Example ## {#example}
-  Requesting a [=periodic Background Sync opportunity=] at a mininimum interval of one day from a [=browsing context=]:
+  Registering periodic background sync at a mininimum interval of one day from a [=browsing context=]:
 
   <pre class="lang-js">
     async function registerPeriodicNewsCheck() {
@@ -58,7 +61,7 @@ Introduction {#intro}
     }
   </pre>
 
-  Reacting to a [=periodicSync event=] within a [=service worker=]:
+  Reacting to a [=periodicsync event=] within a [=service worker=]:
 
   <pre class="lang-js">
     self.addEventListener('periodicsync', event => {
@@ -66,62 +69,78 @@ Introduction {#intro}
     });
   </pre>
 
-  In the above example <code>fetchAndCacheLatestNews</code> is a developer-defined function is a developer-defined function that fetches the latest news articles from a server and stores them locally, for example using the {{Cache}} API, for offline consumption.
+  In the above example `fetchAndCacheLatestNews` is a developer-defined function is a developer-defined function that fetches the latest news articles from a server and stores them locally, for example using the {{Cache}} API, for offline consumption.
 
 Concepts {#concepts}
 ========================
 
-The [=periodicSync event=] is considered to run <dfn>in the background</dfn> if no [=service worker clients=] whose [=frame type=] is top-level or auxiliary exist for the origin of the corresponding service worker registration.
+When a [=periodicsync event=] is fired for a [=periodic sync registration=] |registration|, it is considered to run <dfn for="periodicsync event">in the background</dfn> if no [=service worker clients=] whose [=frame type=] is "`top-level`", "`auxiliary`" or "`nested`" exist for the [=origin=] of the [=periodic sync registration/service worker registration=] associated with |registration|.
 
-The user agent is considered to be [=online=] if the user agent has established a network connection. A user agent MAY use a stricter definition of being [=online=]. Such a stricter definition MAY take into account the particular [=service worker=] or origin a [=periodicsync registration=] is associated with.
-
-A <dfn>periodic Background Sync opportunity</dfn> allows periodic synchronization between the server and the web app, the exact interval of which is decided by the user agent. This can be requested through {{PeriodicSyncManager/register()}}.
+Extensions to service worker registration {#extensions-to-service-worker-registration}
+======================================================================================
+A [=/service worker registration=] additionally has:
+* <dfn>Active periodic sync registrations</dfn> (a [=map=]), where each key is a {{DOMString}}, and each item is a [=periodic sync registration=].
+* <dfn>Periodic sync processing queue</dfn>, initially the result of [=starting a new parallel queue=].
 
 Constructs {#constructs}
 =========================
-The user agent has a <dfn>periodicsync processing queue</dfn> (a [=parallel queue=]), initially the result of [=starting a new parallel queue=].
 
-A [=/service worker registration=] has an associated <dfn>list of periodicsync registrations</dfn> whose element type is a [=periodicsync registration=].
+## Periodic sync registration ## {#periodic-sync-registration-construct}
+A <dfn>periodic sync registration</dfn> consists of:
+<div dfn-for="periodic sync registration">
+A <dfn>service worker registration</dfn>, which is a [=/service worker registration=].
 
-## PeriodicSync Registration ## {#periodic-sync-registration}
-A <dfn>periodicsync registration</dfn> is a tuple consisting of:
-<div dfn-for="periodicsync registration">
-A <dfn>service worker registration</dfn>, which is the [=/service worker registration=] associated with the [=context object=] the {{PeriodicSyncManager}} belongs to.
+A <dfn>tag</dfn>, which is a {{DOMString}}.
 
-A <dfn>tag</dfn>, which is a {{DOMString}}. Within one [=list of periodicsync registrations=] each [=periodicsync registration=] MUST have a unique [=periodicsync registration/tag=]. Periodic Background Sync doesn't share namespace with Background Sync, so an [=origin=] can have registrations of both types with the same tag.
+Note: Periodic Background Sync doesn't share namespace with Background Sync, so an [=origin=] can have registrations of both types with the same tag.
 
-<dfn>options</dfn>, which is a dictionary containing [=options/minInterval=].  Enclosing [=options=] in a dictionary allows this spec to be extended with more [=options=] in the future without adversely affecting existing usage.
+<dfn>minimum interval</dfn> (a long long), which is used to specify the minimum interval, in milliseconds, at which the periodic synchronization should happen. [=minimum interval=] is a suggestion to the user agent.
 
-<div dfn-for=options><dfn>minInterval</dfn> (a long long), which is used to specify the minimum interval, in milliseconds, at which the periodic synchronization should happen. [=options/minInterval=] is a suggestion to the user agent. The actual interval at which [=periodicSync event|periodicSync events=] are fired MUST be greater than or equal to this.</div>
+Note: The actual interval at which [=periodicsync event|periodicsync events=] are fired MUST be greater than or equal to this.
 
-A <dfn>time to fire</dfn> (a timestamp), which is the soonest time [=calculate a time to fire| calculated=] by the user agent at which it is appropriate to fire the next [=periodicSync event=] for the [=periodicsync registration=].
+A <dfn>time to fire</dfn> (a timestamp), which is the soonest time [=calculate a time to fire| calculated=] by the user agent at which it is appropriate to fire the next [=periodicsync event=] for the [=periodic sync registration=].
 
-A <dfn>count of retries</dfn> (a number), which is the number of retries attempted for the most recent [=periodicSync event=] for the [=periodicsync registration=].
-
-A <dfn>registration state</dfn>, which is one of <dfn>pending</dfn>, <dfn>firing</dfn>, or <dfn>reregisteredWhileFiring</dfn>. It is initially set to [=pending=].
+A <dfn>state</dfn>, which is one of "`pending`", "`firing`", "`suspended`" or "`reregistered-while-firing`". It is initially set to "`pending`".
 </div>
+
+## <dfn>Periodic Sync Scheduler</dfn> ## {#periodic-sync-scheduler-construct}
+The [=periodic sync scheduler=] is responsible for scheduling firing of [=periodicsync events=].
+In response to these triggers, the scheduler either schedules delayed processing to fire a [=periodicsync event=] at the appropriate time in the future, or cancels such scheduling.
+
+  <div dfn-for="periodic sync scheduler">
+    The scheduler maintains:
+    * The <dfn>time of last fire</dfn>, a [=map=], where each key is an [=origin=], and each item is a timestamp. The keys of this map are the [=origin|origins=] associated with the [=periodic sync registration/service worker registration|service worker registrations=] of [=active periodic sync registrations=]. This is initially an empty [=map=].
+    * <dfn>Effective minimum interval</dfn>, a [=map=], where each key is an [=origin=], and each item is a long long, representing a time interval. The keys of this map are the [=origin|origins=] associated with the [=periodic sync registration/service worker registration|service worker registrations=] of [=active periodic sync registrations=]. This is initially an empty [=map=].
+  </div>
+
+  The scheduler [=process periodic sync registrations|processes periodic sync registrations=].
+
+  Note: Browsers may suspend this processing loop when there are no [=active periodic sync registrations=] to conserve resources.
 
 ## Constants ## {#constants}
 As recommended in [[#privacy]] and [[#resources]], the user agent SHOULD also define:
-* <dfn>minimum interval for any origin</dfn>, a long long, that represents the minimum gap between [=periodicSync event|periodicSync events=] for any given origin, and,
-* <dfn>minimum interval across origins</dfn>, a long long, that represents the minimum gap between [=periodicSync event|periodicSync events=] across all origins.
+* <dfn>minimum periodic sync interval for any origin</dfn>, a long long, that represents the minimum gap between [=periodicsync event|periodicsync events=] for any given origin, and,
+* <dfn>minimum periodic sync interval across origins</dfn>, a long long, that represents the minimum gap between [=periodicsync event|periodicsync events=] across all origins.
 
-The user agent MAY define a <dfn>maximum number of retries</dfn>, a number, allowed for each [=periodicSync event=]. In choosing this, the user agent SHOULD ensure that the time needed to attempt the [=maximum number of retries=] is an order of magnitude smaller than the [=minimum interval for any origin=].
+[=minimum periodic sync interval across origins=] MUST be greater than or equal to [=minimum periodic sync interval for any origin=].
+If undefined, these are set to 43200000, which is twelve hours in milliseconds.
 
-## Global State ## {#global-state}
-A user agent SHOULD keep track of the <dfn>time the last [=periodicSync event=]  was fired</dfn>, a timestamp representing the time a [=periodicSync event=] was fired for any [=periodicsync registration=].
+Note: Two caps on frequency are needed because conforming to the cap enforced by [=minimum periodic sync interval for any origin=] for each origin can still cause the browser to fire [=periodicsync events=] very frequently. This can happen, for instance, when there are many [=periodic sync registration|periodic sync registrations=] for different origins. [=minimum periodic sync interval across origins=] ensures there's a global cap on how often these events are fired.
+
+The user agent MAY define a <dfn>maximum number of retries</dfn>, a number, allowed for each [=periodicsync event=]. In choosing this, the user agent SHOULD ensure that the time needed to attempt the [=maximum number of retries=] is an order of magnitude smaller than the [=minimum periodic sync interval for any origin=]. If undefined, this number is zero.
 
 Privacy Considerations {#privacy}
 ==================================
 
 ## Permission ## {#permission}
-Periodic Background Sync is only available if the {{PermissionState}} for a {{PermissionDescriptor}} with {{PermissionDescriptor/name}} <code>"periodic-background-sync"</code> is {{PermissionState/granted}}. In addition, user agents SHOULD offer a way for the user to disable Periodic Background Sync.
+Periodic Background Sync is only available if the {{PermissionState}} for a {{PermissionDescriptor}} with {{PermissionDescriptor/name}} `"periodic-background-sync"` is {{PermissionState/granted}}. In addition, user agents SHOULD offer a way for the user to disable Periodic Background Sync.
+When Periodic Background Sync is disabled, [=periodicsync event|periodicsync events=] MUST NOT be dispatched for the [=periodic sync registration|periodic sync registrations=] affected by this permission. (See [[#responding-to-permission-revocation-algorithm]]).
 
 ## Location Tracking ## {#location-tracking}
-Fetch requests within the [=periodicSync event=] while [=in the background=] may reveal the client's IP address to the server after the user has left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of [=periodicSync event=]s, to reduce the amount of time the user's location can be tracked by the website. Further, the user agent SHOULD limit persistent location tracking by capping the frequency of [=periodicSync event=]s, both for an [=origin=], and across [=origin|origins=].
+Fetch requests within the [=periodicsync event=] while [=periodicsync event/in the background=] may reveal the client's IP address to the server after the user has left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of [=periodicsync event=]s, to reduce the amount of time the user's location can be tracked by the website. Further, the user agent SHOULD limit persistent location tracking by capping the frequency of [=periodicsync event=]s, both for an [=origin=], and across [=origin|origins=].
 
 ## History Leaking ## {#history-leaking}
-Fetch requests within the [=periodicSync event=] while [=in the background=] may reveal something about the client's navigation history to middleboxes on networks different from the one used to create the [=periodicsync registration=]. For instance, the client might visit site https://example.com, which registers a [=periodicSync event=], but based on the implementation, might not fire until after the user has navigated away from the page and changed networks. Middleboxes on the new network may see the fetch requests that the [=periodicSync event=] makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request). To prevent this leakage of browsing history, the user agent MAY choose to only fire [=periodicSync event=]s on the network the [=periodicsync registration=] was made on, with the understanding that it will reduce usability by not allowing synchronization opportunistically.
+Fetch requests within the [=periodicsync event=] while [=periodicsync event/in the background=] may reveal something about the client's navigation history to middleboxes on networks different from the one used to create the [=periodic sync registration=]. For instance, the client might visit site https://example.com, which registers a [=periodicsync event=], but based on the implementation, might not fire until after the user has navigated away from the page and changed networks. Middleboxes on the new network may see the fetch requests that the [=periodicsync event=] makes. The fetch requests are HTTPS so the request contents will not be leaked but the destination of the fetch request and domain may be (via DNS lookups and IP address of the request). To prevent this leakage of browsing history, the user agent MAY choose to only fire [=periodicsync event|periodicsync events=] on the network the [=periodic sync registration=] was made on, with the understanding that it will reduce usability by not allowing synchronization opportunistically.
 
 Resource Usage {#resources}
 ============================
@@ -133,42 +152,54 @@ The user agent should cap the duration and frequency of these events to limit re
 
 Large resources should be downloaded by registering a [=background fetch=] via the {{BackgroundFetchManager}} interface.
 
-In addition, the user agent should consider other factors such as user engagement with the [=origin=], and any user indications to temporarily reduce data consumption, such as a Data Saving Mode, to adjust the frequency of [=periodicsync event|periodicSync events=].
+In addition, the user agent should consider other factors such as user engagement with the [=origin=], and any user indications to temporarily reduce data consumption, such as a Data Saving Mode, to adjust the frequency of [=periodicsync event|periodicsync events=].
 
 Algorithms {#algorithms}
 =========================
-## <dfn>Calculate a time to fire</dfn> ## {#caculate-time-to-fire}
-This section describes how a user agent can calculate the [=periodicsync registration/time to fire=] for a [=periodicsync registration=], |registration|. The time interval between [=periodicSync event|periodicSync events=] for |registration| MUST be greater than or equal to |registration|'s [=options/minInterval=] value.
+  <div algorithm>
+    ## <dfn>Calculate a time to fire</dfn> ## {#caculate-time-to-fire}
+    This section describes how a user agent can calculate the [=periodic sync registration/time to fire=] for a [=periodic sync registration=], |registration|. [=periodic sync registration/time to fire=] value MUST be updated in response to various triggers such as registration, unregistration, change in [=online=] status, and completion of an attempt to fire a [=periodicsync event=].
 
-The user agent MAY include factors such as user engagement with the origin to decide this time interval, allowing origins with high user engagement to update their web apps more often. The user agent SHOULD also ensure this time interval conforms to the caps asserted by [=minimum interval for any origin=] and the [=minimum interval across origins=].
+    Calculating the [=periodic sync registration/time to fire=] for |registration| involves running these steps:
+      1. Let |now|, a timestamp, represent the current time.
+      1. Let |origin| be the [=origin=] associated with |registration|'s [=periodic sync registration/service worker registration=].
+      1. Let |effectiveMinimumIntervalForOrigin| be the greater of [=minimum periodic sync interval for any origin=] and |registration|'s [=periodic sync registration/minimum interval=].
+      1. Increment |effectiveMinimumIntervalForOrigin| by some user agent defined amount.
+      
+         Note: User agents can use this to delay synchronization due to the user's engagement with |origin|.
 
-The user agent MAY also decide to [=retry=] each failed [=periodicSync event=] , with the count of retries capped to [=maximum number of retries=].
+      1. Set [=periodic sync scheduler/effective minimum interval=] for |origin| to |effectiveMinimumIntervalForOrigin|.
+      1. Set [=periodic sync registration/time to fire=] to |now| + |effectiveMinimumIntervalForOrigin|.
+  </div>
 
-A possible algorithm to calculate the [=periodicsync registration/time to fire=], |timeToFire| for |registration| would involve running these steps:
-1. If [=periodicsync registration/count of retries=] for |registration| is 0, <dfn>calculate the time to fire of the first attempt of</dfn> the [=periodicSync event=] :
-    1. Let |now|, a timestmap, represent the current time.
-    1. Let |origin| represent [=periodicsync registration/service worker registration=]'s [=origin=]. Let |penalty| be a user agent defined penalty to account for the level of user engagement with the origin. Calculate |minimumIntervalForOrigin| as |penalty|*[=minimum interval for any origin=].
-    1. Set |delayForOrigin| to the multiple of |minimumIntervalForOrigin| greater than or equal to [=options/minInterval=].
-    1. Let |timeTillScheduledEventForOrigin|, a number, be the time till the next scheduled [=periodicSync event=] for |origin|, if any, null otherwise.
-    1. If |timeTillScheduledEventForOrigin| is not null:
-        1. If |timeTillScheduledEventForOrigin| - |delayForOrigin| is greater than or equal to |minIntervalForOrigin|, abort these substeps.
-        1. If |delayForOrigin| is less than or equal to |timeTillScheduledEventForOrigin|, set |delayForOrigin| to |timeTillScheduledEventForOrigin| and abort these substeps.
-        1. If |delayForOrigin| is less than or equal to |timeTillScheduledEventForOrigin| + |minIntervalForOrigin|, set |delayForOrigin| to |timeTillScheduledEventForOrigin| + |minIntervalForOrigin|.
-    1. Let |timeSinceLastPeriodicSync| be null if [=time the last periodicSync event was fired=] is null, else |now| - [=time the last periodicSync event was fired=].
-    1. If |timeSinceLastPeriodicSync| is null, set |timeToFire| to |delayForOrigin| + |now|.
-    1. Else:
-        1. If |timeSinceLastPeriodicSync| is greater than equal to [=minimum interval across origins=], set |timeToFire| to |delayForOrigin| + |now|.
-        1. Else, set |timeTillNextAllowedPeriodicSync| to [=minimum interval across origins=] - |timeSinceLastPeriodicSync|. Set |timeToFire| to the maximum of |delayForOrigin| + |now|, and |timeTillNextAllowedPeriodicSync| + |now|.
-    1. Set the [=periodicsync registration/time to fire=] of |registration| to |timeToFire|.
-1. Else:
-    1. Increment [=periodicsync registration/count of retries=].
-    1. If [=periodicsync registration/count of retries=] is greater than the [=maximum number of retries=] allowed, set [=periodicsync registration/count of retries=] to 0 and follow the steps to [=calculate the time to fire of the first attempt of=] the periodicSync event.
-    1. Else, Set the [=periodicsync registration/time to fire=] of |registration| to |now| + a small back-off that is exponentially proportional to [=periodicsync registration/count of retries=].
+  <div algorithm>
+    ## <dfn>Process periodic sync registrations</dfn> ## {#process-periodic-sync-registrations-algorithm}
+    When the user agent starts, run the following steps [=in parallel=]:
+    1. While true:
+        1. Wait for [=minimum periodic sync interval across origins=].
+        1. Let |firedPeriodicSync| be false.
+        1. While |firedPeriodicSync| is false:
+          1. Wait for some user agent defined amount of time.
 
-## <dfn>Schedule processing</dfn> ## {#schedule-delayed-processing}
-To [=schedule processing=] of a [=periodicSync registration=] |registration|, run the following steps:
-1. Assert: |registration|'s associated [=periodicsync registration/registration state=] is [=pending=].
-1. Schedule [=fire a periodicSync event|firing a periodicSync event=] for |registration| as soon as the the device is online at or after |registration|'s [=periodicsync registration/time to fire=].
+            Note: This can be used to group synchronization for different [=periodic sync registrations=] into a single device wake-up.
+
+          1. Wait until [=online=].
+          1. For each [=/service worker registration=] |registration|, [=enqueue the following steps=] to its [=periodic sync processing queue=]:
+            1. Let |origin| be the [=origin=] associated with |periodicSyncRegistration|'s [=periodic sync registration/service worker registration=].
+            1. If [=periodic sync scheduler/time of last fire=] for |origin| + [=periodic sync scheduler/effective minimum interval=] for |origin| is greater than now, continue.
+            1. For each [=periodic sync registration=] |periodicSyncRegistration| in |registration|'s [=active periodic sync registrations=]:
+              1. If |periodicSyncRegistration|'s [=periodic sync registration/state=] is not "`pending`", continue.
+              1. If |periodicSyncRegistration|'s [=periodic sync registration/time to fire=] is in the future, continue.
+              1. Set |firedPeriodicSync| to true.
+              1. [=Fire a periodicsync event=] for |periodicSyncRegistration|.
+  </div>
+
+  <div algorithm>
+    ## <dfn>Respond to permission revocation</dfn> ## {#responding-to-permission-revocation-algorithm}
+    To [=respond to permission revocation|respond to revocation=] of the permission with {{PermissionDescriptor/name}} `"periodic-background-sync"` for [=origin=] |origin|, the user agent MUST [=enqueue the following steps=] to the [=periodic sync processing queue=]:
+    1. For each [=periodic sync registration=] |registration| in [=active periodic sync registrations=] whose [=periodic sync registration/service worker registration=] is associated with the same [=origin=] as |origin|:
+      1. Remove |registration| from [=active periodic sync registrations=].
+  </div>
 
 API Description {#api-description}
 ===================================
@@ -189,9 +220,9 @@ partial interface ServiceWorkerRegistration {
 </script>
 
 <div dfn-for="ServiceWorkerRegistration">
-A {{ServiceWorkerRegistration}} has a <dfn>periodic sync manager</dfn> (a {{PeriodicSyncManager}}), initially a new {{PeriodicSyncManager}} whose {{PeriodicSyncManager/service worker registration}} is the [=context object=]'s [=/service worker registration=].
+A {{ServiceWorkerRegistration}} has a <dfn>periodic sync manager</dfn> (a {{PeriodicSyncManager}}).
 
-The <dfn attribute>periodicSync</dfn> attribute's getter must return the [=context object=]'s [=ServiceWorkerRegistration/periodic sync manager=].
+The <dfn attribute>periodicSync</dfn> attribute's getter must return the [=context object=]'s [=ServiceWorkerRegistration/periodic sync manager=], initially a new {{PeriodicSyncManager}} whose [=PeriodicSyncManager/service worker registration=] is the [=context object=]'s [=/service worker registration=].
 </div>
 
 ## {{PeriodicSyncManager}} interface ## {#periodicsyncmanager-interface}
@@ -208,54 +239,56 @@ dictionary BackgroundSyncOptions {
 };
 </script>
 
-A {{PeriodicSyncManager}} has a <dfn attribute for=PeriodicSyncManager>service worker registration</dfn> (a [=/service worker registration=]).
+<div dfn-for="PeriodicSyncManager">
+A {{PeriodicSyncManager}} has a <dfn>service worker registration</dfn> (a [=/service worker registration=]).
+</div>
 
-The <code><dfn method for=PeriodicSyncManager title="register(tag, options)">register(|tag|, |options|)</dfn></code> method, when invoked, MUST return [=a new promise=] |promise| and run the following steps:
-
-1. Let |serviceWorkerRegistration| be the {{PeriodicSyncManager}}'s associated {{PeriodicSyncManager/service worker registration}}.
-1. If |serviceWorkerRegistration|’s [=active worker=] is null, [=reject=] |promise| with an {{InvalidStateError}} and abort these steps.
-1. Else, [=enqueue the following steps=] to the [=periodicsync processing queue=]:
-    1. If the {{PermissionState}} for a {{PermissionDescriptor}} with {{PermissionDescriptor/name}} <code>"periodic-background-sync"</code> is not {{PermissionState/granted}}, [=reject=] |promise| with a {{NotAllowedError}} and abort these steps.
+  <div algorithm>
+    The <code><dfn method for=PeriodicSyncManager title="register(tag, options)">register(|tag|, |options|)</dfn></code> method, when invoked, MUST return [=a new promise=] |promise| and [=enqueue the following steps=] to the [=periodic sync processing queue=]:
+    1. Let |serviceWorkerRegistration| be the [=PeriodicSyncManager/service worker registration=] associated with the [=context object=]'s {{PeriodicSyncManager}}.
+    1. If |serviceWorkerRegistration|’s [=active worker=] is null, [=reject=] |promise| with an {{InvalidStateError}} and abort these steps.
+    1. If the {{PermissionState}} for a {{PermissionDescriptor}} with {{PermissionDescriptor/name}} `"periodic-background-sync"` is not {{PermissionState/granted}}, [=reject=] |promise| with a {{NotAllowedError}} and abort these steps.
     1. Let |isBackground|, a boolean, be true.
     1. For each |client| in the [=service worker clients=] for the |serviceWorkerRegistration|'s [=origin=]:
-      1. If |client|'s [=frame type=] is top-level or auxillary, set |isBackground| to false.
+      1. If |client|'s [=frame type=] is "`top-level`" or "`auxiliary`", set |isBackground| to false.
     1. If |isBackground| is true, [=reject=] |promise| with an {{InvalidAccessError}} and abort these steps.
-    1. Let |currentRegistration| be the [=periodicsync registration=] in |serviceWorkerRegistration|'s [=list of periodicsync registrations=] whose [=periodicsync registration/tag=] equals |tag| if it exists, else null.
+    1. Let |currentRegistration| be the [=periodic sync registration=] in |serviceWorkerRegistration|'s [=active periodic sync registrations=] whose [=periodic sync registration/tag=] equals |tag| if it exists, else null.
     1. If |currentRegistration| is null:
-        1. Let |newRegistration| be a new [=periodicsync registration=].
-        1. Set |newRegistration|'s associated [=periodicsync registration/tag=] to |tag|.
-        1. Set |newRegistration|'s associated [=periodicsync registration/options=] to |options|.
-        1. Set |newRegistration|'s associated [=periodicsync registration/registration state=] to [=pending=].
-        1. Set |newRegistration|'s associated [=periodicsync registration/service worker registration=] to |serviceWorkerRegistration|.
-        1. Add |newRegistration| to |serviceWorkerRegistration|'s [=list of periodicsync registrations=].
+        1. Let |newRegistration| be a new [=periodic sync registration=].
+        1. Set |newRegistration|'s associated [=periodic sync registration/tag=] to |tag|.
+        1. Set |newRegistration|'s associated [=periodic sync registration/minimum interval=] to |options|.|minInterval|.
+        1. Set |newRegistration|'s associated [=periodic sync registration/state=] to "`pending`".
+        1. Set |newRegistration|'s associated [=periodic sync registration/service worker registration=] to |serviceWorkerRegistration|.
+        1. Add |newRegistration| to |serviceWorkerRegistration|'s [=active periodic sync registrations=].
         1. [=Calculate a time to fire=] for |newRegistration|.
-        1. [=Schedule processing=] for |registration|.
         1. [=Resolve=] |promise|.
     1. Else:
-        1. If the |currentRegistration|'s [=periodicsync registration/options=] is different from |options|:
-            1. Set |currentRegistration|'s associated [=periodicsync registration/options=] to |options|.
+        1. If |currentRegistration|'s [=periodic sync registration/minimum interval=] is different to |options|.|minInterval|:
+            1. Set |currentRegistration|'s [=periodic sync registration/minimum interval=] |options|.|minInterval|.
             1. [=Calculate a time to fire=] for |newRegistration|.
-            1. Set |currentRegistration|'s associated [=periodicsync registration/registration state=] to [=pending=].
-        1. Else, if |currentRegistration|'s [=periodicsync registration/registration state=] is [=firing=], set |serviceWorkerRegistration|'s [=periodicsync registration/registration state=] to [=reregisteredWhileFiring=].
+        1. Else, if |currentRegistration|'s [=periodic sync registration/state=] is "`firing`", set |serviceWorkerRegistration|'s [=periodic sync registration/state=] to "`reregistered-while-firing`".
         1. [=Resolve=] |promise|.
+  </div>
 
-The <code><dfn method for=PeriodicSyncManager title="getTags()">getTags()</dfn></code> method when invoked, MUST return [=a new promise=] |promise| and  [=enqueue the following steps=] to the [=periodicsync processing queue=]:
+  <div algorithm>
+    The <code><dfn method for=PeriodicSyncManager title="getTags()">getTags()</dfn></code> method when invoked, MUST return [=a new promise=] |promise| and  [=enqueue the following steps=] to the [=periodic sync processing queue=]:
 
-1. Let |serviceWorkerRegistration| be the {{PeriodicSyncManager}}'s associated [=/service worker registration=].
-1. Let |currentTags| be a new [=/list=].
-1. For each |registration| of |serviceWorkerRegistration|'s [=list of periodicsync registrations=], [=list/append=] |registration|'s [=periodicsync registration/tag=] to |currentTags|.
-1. [=Resolve=] |promise| with |currentTags|.
+    1. Let |serviceWorkerRegistration| be the [=PeriodicSyncManager/service worker registration=] associated with the [=context object=]'s {{PeriodicSyncManager}}.
+    1. Let |currentTags| be a new [=/list=].
+    1. For each |registration| of |serviceWorkerRegistration|'s [=active periodic sync registrations=], [=list/append=] |registration|'s [=periodic sync registration/tag=] to |currentTags|.
+    1. [=Resolve=] |promise| with |currentTags|.
+  </div>
 
-The <code><dfn method for=PeriodicSyncManager title="unregister(tag)">unregister(tag)</dfn></code> method when invoked, MUST return [=a new promise=] <var>promise</var> and run the following steps:
-1. Let <var>serviceWorkerRegistration</var> be the {{PeriodicSyncManager}}'s associated [=/service worker registration=].
-1. If |serviceWorkerRegistration|’s [=active worker=] is null, [=reject=] |promise| with an {{InvalidStateError}} and abort these steps.
-1. Else, [=enqueue the following steps=] to the [=periodicsync processing queue=]:
-    1. Let <var>currentRegistration</var> be the [=periodicsync registration=] in |serviceWorkerRegistration|'s [=list of periodicsync registrations=] whose [=periodicsync registration/tag=] equals <var>tag</var> if it exists, else null.
-    1. If |currentRegistration| is not null, remove |registration| from |serviceWorkerRegistration|'s [=list of periodicsync registrations=].
-    1. Resolve |promise|.
+  <div algorithm>
+    The <code><dfn method for=PeriodicSyncManager title="unregister(tag)">unregister(|tag|)</dfn></code> method when invoked, MUST return [=a new promise=] <var>promise</var> and [=enqueue the following steps=] to the [=periodic sync processing queue=]:
+    1. Let |serviceWorkerRegistration| be the [=PeriodicSyncManager/service worker registration=] associated with the [=context object=]'s {{PeriodicSyncManager}}.
+        1. Let <var>currentRegistration</var> be the [=periodic sync registration=] in |serviceWorkerRegistration|'s [=active periodic sync registrations=] whose [=periodic sync registration/tag=] equals |tag| if it exists, else null.
+        1. If |currentRegistration| is not null, remove |currentRegistration| from |serviceWorkerRegistration|'s [=active periodic sync registrations=].
+        1. Resolve |promise|.
+  </div>
 
 
-## The <dfn>periodicSync event</dfn> ## {#periodicSync-event}
+## The <dfn>periodicsync event</dfn> ## {#periodicsync-event-interface}
 <script type="idl">
 dictionary PeriodicSyncEventInit : ExtendableEventInit {
     required DOMString tag;
@@ -269,25 +302,38 @@ dictionary PeriodicSyncEventInit : ExtendableEventInit {
   };
 </script>
 
-The {{PeriodicSyncEvent}} interface represents a [=firing=] [=periodicsync registration=].
+<div dfn-for="PeriodicSyncEvent">
+  A {{PeriodicSyncEvent}} has a <dfn>tag</dfn> (a [=periodic sync registration/tag=]).
+  The <dfn attribute>tag</dfn> attribute must return the value it was initialized to.
+</div>
 
-### Firing periodicSync events ### {#firing-periodicsync-events}
-Whenever the user agent changes to [=online=], it SHOULD [=fire a periodicSync event=] for each [=periodicsync registration=] whose [=periodicsync registration/registration state=] is [=pending=] and [=periodicsync registration/time to fire=] is now or in the past.
+### [=Fire a periodicsync event=] ### {#firing-a-periodicsync-event}
+Note: A user agent MAY impose a time limit on the lifetime extension and execution time of a {{PeriodicSyncEvent}} which is stricter than the time limit imposed for {{ExtendableEvent}}s in general. In particular, any retries of the {{PeriodicSyncEvent}} MAY have a significantly shortened time limit.
 
-### [=Fire a periodicSync event=] ### {#firing-a-periodicsync-event}
-The user agent will fire a [=periodicSync event=] for a [=periodicsync registration=] as soon as network connectivity is available, at or after the [=periodicsync registration/time to fire=] of the [=periodicsync registration=].
-If a [=periodicSync event=] fails, the user agent MAY <dfn>retry</dfn> it one or more times at a time of its choosing, based on some user agent defined heuristics.
-
-A user agent MAY impose a time limit on the lifetime extension and execution time of a {{PeriodicSyncEvent}} which is stricter than the time limit imposed for {{ExtendableEvent}}s in general. In particular, any retries of the {{PeriodicSyncEvent}} MAY have a significantly shortened time limit.
-
-To <dfn>fire a periodicSync event</dfn> for a [=periodicsync registration=] |registration|, the user agent MUST [=enqueue the following steps=] to the [=periodicsync processing queue=]:
-1. [=Assert=]: |registration|'s [=periodicsync registration/registration state=] is [=pending=].
-1. Let |serviceWorkerRegistration| be |registration|'s [=periodicsync registration/service worker registration=].
-1. [=Assert=]: |registration|'s [=periodicsync registration/time to fire=] is equal to the current time or in the past.
-1. Set |registration|'s [=periodicsync registration/registration state=] to [=firing=].
-1. [=In parallel=], [=fire functional event=] "<code>periodicSync</code>" using {{PeriodicSyncEvent}} on |serviceWorkerRegistration| with {{PeriodicSyncEvent/tag}} set to |registration|'s [=periodicsync registration/tag=]. Let |dispatchedEvent|, an {{ExtendableEvent}}, represent the dispatched [=periodicSync event=], and [=enqueue the following steps=] on the [=periodicsync processing queue=]:
-    1. Let |waitUntilPromise| be the result of [=waiting for all=] of |dispatchedEvent|'s [=extend lifetime promises=].
-    1. [=Upon fulfillment=] or [=Upon rejection|rejection=] of |waitUntilPromise|, or if the script has been aborted by the [=Terminate Service Worker|termination=] of the [=service worker=] of |waitUntilPromise|, run the following steps:
-        1. Set |registration|'s state to [=pending=].
-        1. [=Calculate a time to fire=] for |registration|.
-        1. [=Schedule processing=] for |registration|.
+To <dfn>fire a periodicsync event</dfn> for a [=periodic sync registration=] |registration|, the user agent MUST run the following steps:
+1. Let |serviceWorkerRegistration| be |registration|'s [=periodic sync registration/service worker registration=].
+1. If |registration| is no longer part of |serviceWorkerRegistration|'s [=active periodic sync registrations=], abort these steps.
+1. [=Assert=]: |registration|'s [=periodic sync registration/state=] is "`pending`".
+1. [=Assert=]: |registration|'s [=periodic sync registration/time to fire=] is equal to the current time or in the past.
+1. Let retryCount be 0.
+1. Set |registration|'s [=periodic sync registration/state=] to "`firing`".
+1. While true:
+  1. Let |continue| be false.
+  1. Let |success| be false.
+  1. [=Fire functional event=] "`periodicsync`" using {{PeriodicSyncEvent}} on |serviceWorkerRegistration| with [=PeriodicSyncEvent/tag=] set to |registration|'s [=periodic sync registration/tag=]. Let |dispatchedEvent|, an {{ExtendableEvent}}, represent the dispatched [=periodicsync event=] and run the following steps with |dispatchedEvent|:
+  1. Let |waitUntilPromise| be the result of [=waiting for all=] of |dispatchedEvent|'s [=extend lifetime promises=].
+  1. React to the [=upon fulfillment|fulfillment=] of |waitUntilPromise| with the following steps:
+    1. Set |success| to true.
+    1. Set |continue| to true.
+  1. React to rejection [=upon rejection|rejection=] of |waitUntilPromise| with the following steps:
+    1. Set |continue| to true.
+  1. [=In parallel=]:
+    1. Wait for |continue| to be true.
+    1. Let |origin| be the [=origin=] associated with |registration|'s [=periodic sync registration/service worker registration=].
+    1. If |success| is true, set [=periodic sync scheduler/time of last fire=] for key |origin| to the current time.
+    1. If |success| is true or |retryCount| is greater than [=maximum number of retries=] or |registration|'s state is "`reregistered-while-firing`", then:
+      1. Set |registration|'s [=periodic sync registration/state=] to "<cod>pending`".
+      1. [=Calculate a time to fire=] for |registration|.
+      1. Abort these steps.
+  1. Increment |retryCount|.
+  1. Wait for a small back-off time based on |retryCount|.

--- a/spec/PeriodicBackgroundSync-index.bs
+++ b/spec/PeriodicBackgroundSync-index.bs
@@ -40,7 +40,7 @@ Introduction {#intro}
 
   Web Applications often run in environments with unreliable networks (e.g., mobile phones) and unknown lifetimes (the browser might be killed or the user might navigate away).
   This makes it difficult for web apps to keep their content and state in sync with servers.
-  
+
   This API is intended to reduce the time between content creation and content synchronization between the servers and the web app. It does so by letting the web app register an intent to periodically synchronize state and data, with a minimum interval it wishes to do so at. Through a service worker event, the user agent then periodically lets the web app download network resources and update state.
 
   As this API relies on service workers, functionality provided by this API is only available in a [=secure context=].
@@ -98,7 +98,7 @@ Note: Periodic Background Sync doesn't share namespace with Background Sync, so 
 
 Note: The actual interval at which [=periodicsync event|periodicsync events=] are fired MUST be greater than or equal to this.
 
-A <dfn>time to fire</dfn> (a timestamp), which is the soonest time [=calculate a time to fire| calculated=] by the user agent at which it is appropriate to fire the next [=periodicsync event=] for the [=periodic sync registration=].
+A <dfn>anchor time</dfn> (a timestamp), the previous time a [=periodicsync event=] fired for this [=periodic sync registration=], or the time of initial registration.
 
 A <dfn>state</dfn>, which is one of "`pending`", "`firing`", "`suspended`" or "`reregistered-while-firing`". It is initially set to "`pending`".
 </div>
@@ -110,8 +110,11 @@ In response to these triggers, the scheduler either schedules delayed processing
   <div dfn-for="periodic sync scheduler">
     The scheduler maintains:
     * The <dfn>time of last fire</dfn>, a [=map=], where each key is an [=origin=], and each item is a timestamp. The keys of this map are the [=origin|origins=] associated with the [=periodic sync registration/service worker registration|service worker registrations=] of [=active periodic sync registrations=]. This is initially an empty [=map=].
-    * <dfn>Effective minimum interval</dfn>, a [=map=], where each key is an [=origin=], and each item is a long long, representing a time interval. The keys of this map are the [=origin|origins=] associated with the [=periodic sync registration/service worker registration|service worker registrations=] of [=active periodic sync registrations=]. This is initially an empty [=map=].
   </div>
+
+The <dfn>effective minimum sync interval for origin</dfn> |origin| (an [=origin=]), is the [=minimum periodic sync interval for any origin=] + some user agent defined amount for the |origin|.
+
+Note: The user agent defined amount could be based off the amount of engagement the user has with the origin. This value can be different each time [=effective minimum sync interval for origin=] is called.
 
   The scheduler [=process periodic sync registrations|processes periodic sync registrations=].
 
@@ -156,42 +159,27 @@ In addition, the user agent should consider other factors such as user engagemen
 
 Algorithms {#algorithms}
 =========================
-  <div algorithm>
-    ## <dfn>Calculate a time to fire</dfn> ## {#caculate-time-to-fire}
-    This section describes how a user agent can calculate the [=periodic sync registration/time to fire=] for a [=periodic sync registration=], |registration|. [=periodic sync registration/time to fire=] value MUST be updated in response to various triggers such as registration, unregistration, change in [=online=] status, and completion of an attempt to fire a [=periodicsync event=].
-
-    Calculating the [=periodic sync registration/time to fire=] for |registration| involves running these steps:
-      1. Let |now|, a timestamp, represent the current time.
-      1. Let |origin| be the [=origin=] associated with |registration|'s [=periodic sync registration/service worker registration=].
-      1. Let |effectiveMinimumIntervalForOrigin| be the greater of [=minimum periodic sync interval for any origin=] and |registration|'s [=periodic sync registration/minimum interval=].
-      1. Increment |effectiveMinimumIntervalForOrigin| by some user agent defined amount.
-      
-         Note: User agents can use this to delay synchronization due to the user's engagement with |origin|.
-
-      1. Set [=periodic sync scheduler/effective minimum interval=] for |origin| to |effectiveMinimumIntervalForOrigin|.
-      1. Set [=periodic sync registration/time to fire=] to |now| + |effectiveMinimumIntervalForOrigin|.
-  </div>
 
   <div algorithm>
     ## <dfn>Process periodic sync registrations</dfn> ## {#process-periodic-sync-registrations-algorithm}
     When the user agent starts, run the following steps [=in parallel=]:
     1. While true:
-        1. Wait for [=minimum periodic sync interval across origins=].
-        1. Let |firedPeriodicSync| be false.
-        1. While |firedPeriodicSync| is false:
-          1. Wait for some user agent defined amount of time.
+      1. Wait for [=minimum periodic sync interval across origins=].
+      1. Let |firedPeriodicSync| be false.
+      1. While |firedPeriodicSync| is false:
+        1. Wait for some user agent defined amount of time.
 
-            Note: This can be used to group synchronization for different [=periodic sync registrations=] into a single device wake-up.
+          Note: This can be used to group synchronization for different [=periodic sync registrations=] into a single device wake-up.
 
-          1. Wait until [=online=].
-          1. For each [=/service worker registration=] |registration|, [=enqueue the following steps=] to its [=periodic sync processing queue=]:
-            1. Let |origin| be the [=origin=] associated with |periodicSyncRegistration|'s [=periodic sync registration/service worker registration=].
-            1. If [=periodic sync scheduler/time of last fire=] for |origin| + [=periodic sync scheduler/effective minimum interval=] for |origin| is greater than now, continue.
-            1. For each [=periodic sync registration=] |periodicSyncRegistration| in |registration|'s [=active periodic sync registrations=]:
-              1. If |periodicSyncRegistration|'s [=periodic sync registration/state=] is not "`pending`", continue.
-              1. If |periodicSyncRegistration|'s [=periodic sync registration/time to fire=] is in the future, continue.
-              1. Set |firedPeriodicSync| to true.
-              1. [=Fire a periodicsync event=] for |periodicSyncRegistration|.
+        1. Wait until [=online=].
+        1. For each [=/service worker registration=] |registration| that is not [=service worker registration/unregistered=], [=enqueue the following steps=] to |registration|'s [=periodic sync processing queue=]:
+          1. Let |origin| be the [=origin=] associated with |periodicSyncRegistration|'s [=periodic sync registration/service worker registration=].
+          1. If [=periodic sync scheduler/time of last fire=][|origin|] + the [=effective minimum sync interval for origin=] |origin| is greater than now, [=continue=].
+          1. For each [=periodic sync registration=] |periodicSyncRegistration| in |registration|'s [=active periodic sync registrations=]:
+            1. If |periodicSyncRegistration|'s [=periodic sync registration/state=] is not "`pending`", [=continue=].
+            1. If |periodicSyncRegistration|'s [=periodic sync registration/anchor time=] + |periodicSyncRegistration|'s [=periodic sync registration/minimum interval=] is greater than now, [=continue=].
+            1. Set |firedPeriodicSync| to true.
+            1. [=Fire a periodicsync event=] for |periodicSyncRegistration|.
   </div>
 
   <div algorithm>
@@ -255,19 +243,18 @@ A {{PeriodicSyncManager}} has a <dfn>service worker registration</dfn> (a [=/ser
     1. Let |currentRegistration| be the [=periodic sync registration=] in |serviceWorkerRegistration|'s [=active periodic sync registrations=] whose [=periodic sync registration/tag=] equals |tag| if it exists, else null.
     1. If |currentRegistration| is null:
         1. Let |newRegistration| be a new [=periodic sync registration=].
-        1. Set |newRegistration|'s associated [=periodic sync registration/tag=] to |tag|.
-        1. Set |newRegistration|'s associated [=periodic sync registration/minimum interval=] to |options|.|minInterval|.
-        1. Set |newRegistration|'s associated [=periodic sync registration/state=] to "`pending`".
-        1. Set |newRegistration|'s associated [=periodic sync registration/service worker registration=] to |serviceWorkerRegistration|.
+        1. Set |newRegistration|'s [=periodic sync registration/tag=] to |tag|.
+        1. Set |newRegistration|'s [=periodic sync registration/minimum interval=] to |options|' {{BackgroundSyncOptions/minInterval}} member.
+        1. Set |newRegistration|'s [=periodic sync registration/state=] to "`pending`".
+        1. Set |newRegistration|'s [=periodic sync registration/service worker registration=] to |serviceWorkerRegistration|.
+        1. Set |newRegistration|'s [=periodic sync registration/anchor time=] to a timestamp representing now.
         1. Add |newRegistration| to |serviceWorkerRegistration|'s [=active periodic sync registrations=].
-        1. [=Calculate a time to fire=] for |newRegistration|.
         1. [=Resolve=] |promise|.
     1. Else:
-        1. If |currentRegistration|'s [=periodic sync registration/minimum interval=] is different to |options|.|minInterval|:
-            1. Set |currentRegistration|'s [=periodic sync registration/minimum interval=] |options|.|minInterval|.
-            1. [=Calculate a time to fire=] for |newRegistration|.
-        1. Else, if |currentRegistration|'s [=periodic sync registration/state=] is "`firing`", set |serviceWorkerRegistration|'s [=periodic sync registration/state=] to "`reregistered-while-firing`".
-        1. [=Resolve=] |promise|.
+      1. If |currentRegistration|'s [=periodic sync registration/minimum interval=] is different to |options|' {{BackgroundSyncOptions/minInterval}} member:
+        1. Set |currentRegistration|'s [=periodic sync registration/minimum interval=] to |options|' {{BackgroundSyncOptions/minInterval}} member.
+      1. Else, if |currentRegistration|'s [=periodic sync registration/state=] is "`firing`", set |serviceWorkerRegistration|'s [=periodic sync registration/state=] to "`reregistered-while-firing`".
+      1. [=Resolve=] |promise|.
   </div>
 
   <div algorithm>
@@ -310,30 +297,31 @@ dictionary PeriodicSyncEventInit : ExtendableEventInit {
 ### [=Fire a periodicsync event=] ### {#firing-a-periodicsync-event}
 Note: A user agent MAY impose a time limit on the lifetime extension and execution time of a {{PeriodicSyncEvent}} which is stricter than the time limit imposed for {{ExtendableEvent}}s in general. In particular, any retries of the {{PeriodicSyncEvent}} MAY have a significantly shortened time limit.
 
-To <dfn>fire a periodicsync event</dfn> for a [=periodic sync registration=] |registration|, the user agent MUST run the following steps:
-1. Let |serviceWorkerRegistration| be |registration|'s [=periodic sync registration/service worker registration=].
-1. If |registration| is no longer part of |serviceWorkerRegistration|'s [=active periodic sync registrations=], abort these steps.
-1. [=Assert=]: |registration|'s [=periodic sync registration/state=] is "`pending`".
-1. [=Assert=]: |registration|'s [=periodic sync registration/time to fire=] is equal to the current time or in the past.
-1. Let retryCount be 0.
-1. Set |registration|'s [=periodic sync registration/state=] to "`firing`".
-1. While true:
-  1. Let |continue| be false.
-  1. Let |success| be false.
-  1. [=Fire functional event=] "`periodicsync`" using {{PeriodicSyncEvent}} on |serviceWorkerRegistration| with [=PeriodicSyncEvent/tag=] set to |registration|'s [=periodic sync registration/tag=]. Let |dispatchedEvent|, an {{ExtendableEvent}}, represent the dispatched [=periodicsync event=] and run the following steps with |dispatchedEvent|:
-  1. Let |waitUntilPromise| be the result of [=waiting for all=] of |dispatchedEvent|'s [=extend lifetime promises=].
-  1. React to the [=upon fulfillment|fulfillment=] of |waitUntilPromise| with the following steps:
-    1. Set |success| to true.
-    1. Set |continue| to true.
-  1. React to rejection [=upon rejection|rejection=] of |waitUntilPromise| with the following steps:
-    1. Set |continue| to true.
-  1. [=In parallel=]:
-    1. Wait for |continue| to be true.
-    1. Let |origin| be the [=origin=] associated with |registration|'s [=periodic sync registration/service worker registration=].
-    1. If |success| is true, set [=periodic sync scheduler/time of last fire=] for key |origin| to the current time.
-    1. If |success| is true or |retryCount| is greater than [=maximum number of retries=] or |registration|'s state is "`reregistered-while-firing`", then:
-      1. Set |registration|'s [=periodic sync registration/state=] to "<cod>pending`".
-      1. [=Calculate a time to fire=] for |registration|.
-      1. Abort these steps.
-  1. Increment |retryCount|.
-  1. Wait for a small back-off time based on |retryCount|.
+<div algorithm>
+  To <dfn>fire a periodicsync event</dfn> for a [=periodic sync registration=] |registration|, the user agent MUST run the following steps:
+  1. Let |serviceWorkerRegistration| be |registration|'s [=periodic sync registration/service worker registration=].
+  1. If |registration| is no longer part of |serviceWorkerRegistration|'s [=active periodic sync registrations=], abort these steps.
+  1. [=Assert=]: |registration|'s [=periodic sync registration/state=] is "`pending`".
+  1. Let retryCount be 0.
+  1. Set |registration|'s [=periodic sync registration/state=] to "`firing`".
+  1. While true:
+    1. Let |continue| be false.
+    1. Let |success| be false.
+    1. [=Fire functional event=] "`periodicsync`" using {{PeriodicSyncEvent}} on |serviceWorkerRegistration| with [=PeriodicSyncEvent/tag=] set to |registration|'s [=periodic sync registration/tag=]. Let |dispatchedEvent|, an {{ExtendableEvent}}, represent the dispatched [=periodicsync event=] and run the following steps with |dispatchedEvent|:
+    1. Let |waitUntilPromise| be the result of [=waiting for all=] of |dispatchedEvent|'s [=extend lifetime promises=].
+    1. React to the [=upon fulfillment|fulfillment=] of |waitUntilPromise| with the following steps:
+      1. Set |success| to true.
+      1. Set |continue| to true.
+    1. React to rejection [=upon rejection|rejection=] of |waitUntilPromise| with the following steps:
+      1. Set |continue| to true.
+    1. [=In parallel=]:
+      1. Wait for |continue| to be true.
+      1. Let |origin| be the [=origin=] associated with |registration|'s [=periodic sync registration/service worker registration=].
+      1. If |success| is true, set [=periodic sync scheduler/time of last fire=] for key |origin| to the current time.
+      1. If |success| is true or |retryCount| is greater than [=maximum number of retries=] or |registration|'s state is "`reregistered-while-firing`", then:
+        1. Set |registration|'s [=periodic sync registration/state=] to "`pending`".
+        1. Set |registration|'s [=periodic sync registration/anchor time=] to a timestamp representing now.
+        1. Abort these steps.
+    1. Increment |retryCount|.
+    1. Wait for a small back-off time based on |retryCount|.
+</div>

--- a/spec/PeriodicBackgroundSync-index.bs
+++ b/spec/PeriodicBackgroundSync-index.bs
@@ -98,7 +98,7 @@ Note: Periodic Background Sync doesn't share namespace with Background Sync, so 
 
 Note: The actual interval at which [=periodicsync event|periodicsync events=] are fired MUST be greater than or equal to this.
 
-A <dfn>anchor time</dfn> (a timestamp), the previous time a [=periodicsync event=] fired for this [=periodic sync registration=], or the time of initial registration.
+An <dfn>anchor time</dfn> (a timestamp), the previous time a [=periodicsync event=] fired for this [=periodic sync registration=], or the time of initial registration.
 
 A <dfn>state</dfn>, which is one of "`pending`", "`firing`", "`suspended`" or "`reregistered-while-firing`". It is initially set to "`pending`".
 </div>

--- a/spec/PeriodicBackgroundSync-index.html
+++ b/spec/PeriodicBackgroundSync-index.html
@@ -1215,7 +1215,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 60a9f27730c0c9ae3e20485f824cef3713caf5fb" name="generator">
   <link href="https://wicg.github.io/BackgroundSync/spec/PeriodicBackgroundSync-index.html" rel="canonical">
-  <meta content="38ad042d61de1d7d3b6e7692c0c0aa7111b7be49" name="document-revision">
+  <meta content="e9588bb4066a6031fc92354497a365c03913653b" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1301,6 +1301,17 @@ figcaption {
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }</style>
+<style>/* style-var-click-highlighting */
+
+    var { cursor: pointer; }
+    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+    </style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1462,15 +1473,16 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Periodic Background Synchronization</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-12-02">2 December 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-12-05">5 December 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/BackgroundSync/spec/PeriodicBackgroundSync-index.html">https://wicg.github.io/BackgroundSync/spec/PeriodicBackgroundSync-index.html</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/WICG/BackgroundSync/issues/">GitHub</a>
-     <dt class="editor">Editor:
+     <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:nator@chromium.org">Mugdha Lakhani</a> (<span class="p-org org">Google</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:jakearchibald@chromium.org">Jake Archibald</a> (<span class="p-org org">Google</span>)
     </dl>
    </div>
    <div data-fill-with="warning"></div>
@@ -1503,38 +1515,39 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#example"><span class="secno">1.1</span> <span class="content">Example</span></a>
      </ol>
     <li><a href="#concepts"><span class="secno">2</span> <span class="content">Concepts</span></a>
+    <li><a href="#extensions-to-service-worker-registration"><span class="secno">3</span> <span class="content">Extensions to service worker registration</span></a>
     <li>
-     <a href="#constructs"><span class="secno">3</span> <span class="content">Constructs</span></a>
+     <a href="#constructs"><span class="secno">4</span> <span class="content">Constructs</span></a>
      <ol class="toc">
-      <li><a href="#periodic-sync-registration"><span class="secno">3.1</span> <span class="content">PeriodicSync Registration</span></a>
-      <li><a href="#constants"><span class="secno">3.2</span> <span class="content">Constants</span></a>
-      <li><a href="#global-state"><span class="secno">3.3</span> <span class="content">Global State</span></a>
+      <li><a href="#periodic-sync-registration-construct"><span class="secno">4.1</span> <span class="content">Periodic sync registration</span></a>
+      <li><a href="#periodic-sync-scheduler-construct"><span class="secno">4.2</span> <span class="content"><span>Periodic Sync Scheduler</span></span></a>
+      <li><a href="#constants"><span class="secno">4.3</span> <span class="content">Constants</span></a>
      </ol>
     <li>
-     <a href="#privacy"><span class="secno">4</span> <span class="content">Privacy Considerations</span></a>
+     <a href="#privacy"><span class="secno">5</span> <span class="content">Privacy Considerations</span></a>
      <ol class="toc">
-      <li><a href="#permission"><span class="secno">4.1</span> <span class="content">Permission</span></a>
-      <li><a href="#location-tracking"><span class="secno">4.2</span> <span class="content">Location Tracking</span></a>
-      <li><a href="#history-leaking"><span class="secno">4.3</span> <span class="content">History Leaking</span></a>
+      <li><a href="#permission"><span class="secno">5.1</span> <span class="content">Permission</span></a>
+      <li><a href="#location-tracking"><span class="secno">5.2</span> <span class="content">Location Tracking</span></a>
+      <li><a href="#history-leaking"><span class="secno">5.3</span> <span class="content">History Leaking</span></a>
      </ol>
-    <li><a href="#resources"><span class="secno">5</span> <span class="content">Resource Usage</span></a>
+    <li><a href="#resources"><span class="secno">6</span> <span class="content">Resource Usage</span></a>
     <li>
-     <a href="#algorithms"><span class="secno">6</span> <span class="content">Algorithms</span></a>
+     <a href="#algorithms"><span class="secno">7</span> <span class="content">Algorithms</span></a>
      <ol class="toc">
-      <li><a href="#caculate-time-to-fire"><span class="secno">6.1</span> <span class="content"><span>Calculate a time to fire</span></span></a>
-      <li><a href="#schedule-delayed-processing"><span class="secno">6.2</span> <span class="content"><span>Schedule processing</span></span></a>
+      <li><a href="#caculate-time-to-fire"><span class="secno">7.1</span> <span class="content"><span>Calculate a time to fire</span></span></a>
+      <li><a href="#process-periodic-sync-registrations-algorithm"><span class="secno">7.2</span> <span class="content"><span>Process periodic sync registrations</span></span></a>
+      <li><a href="#responding-to-permission-revocation-algorithm"><span class="secno">7.3</span> <span class="content"><span>Respond to permission revocation</span></span></a>
      </ol>
     <li>
-     <a href="#api-description"><span class="secno">7</span> <span class="content">API Description</span></a>
+     <a href="#api-description"><span class="secno">8</span> <span class="content">API Description</span></a>
      <ol class="toc">
-      <li><a href="#extensions-to-serviceworkerglobalscope"><span class="secno">7.1</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerGlobalScope</span></code> interface</span></a>
-      <li><a href="#extensions-to-serviceworkerregistration"><span class="secno">7.2</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerRegistration</span></code> interface</span></a>
-      <li><a href="#periodicsyncmanager-interface"><span class="secno">7.3</span> <span class="content"><code class="idl"><span>PeriodicSyncManager</span></code> interface</span></a>
+      <li><a href="#extensions-to-serviceworkerglobalscope"><span class="secno">8.1</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerGlobalScope</span></code> interface</span></a>
+      <li><a href="#extensions-to-serviceworkerregistration"><span class="secno">8.2</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerRegistration</span></code> interface</span></a>
+      <li><a href="#periodicsyncmanager-interface"><span class="secno">8.3</span> <span class="content"><code class="idl"><span>PeriodicSyncManager</span></code> interface</span></a>
       <li>
-       <a href="#periodicSync-event"><span class="secno">7.4</span> <span class="content">The <span>periodicSync event</span></span></a>
+       <a href="#periodicsync-event-interface"><span class="secno">8.4</span> <span class="content">The <span>periodicsync event</span></span></a>
        <ol class="toc">
-        <li><a href="#firing-periodicsync-events"><span class="secno">7.4.1</span> <span class="content">Firing periodicSync events</span></a>
-        <li><a href="#firing-a-periodicsync-event"><span class="secno">7.4.2</span> <span class="content"><span>Fire a periodicSync event</span></span></a>
+        <li><a href="#firing-a-periodicsync-event"><span class="secno">8.4.1</span> <span class="content"><span>Fire a periodicsync event</span></span></a>
        </ol>
      </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
@@ -1560,7 +1573,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <p>This API is intended to reduce the time between content creation and content synchronization between the servers and the web app. It does so by letting the web app register an intent to periodically synchronize state and data, with a minimum interval it wishes to do so at. Through a service worker event, the user agent then periodically lets the web app download network resources and update state.</p>
    <p>As this API relies on service workers, functionality provided by this API is only available in a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts">secure context</a>.</p>
    <h3 class="heading settled" data-level="1.1" id="example"><span class="secno">1.1. </span><span class="content">Example</span><a class="self-link" href="#example"></a></h3>
-    Requesting a <a data-link-type="dfn" href="#periodic-background-sync-opportunity" id="ref-for-periodic-background-sync-opportunity">periodic Background Sync opportunity</a> at a mininimum interval of one day from a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>: 
+    Registering periodic background sync at a mininimum interval of one day from a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>: 
 <pre class="lang-js highlight">async <c- a>function</c-> registerPeriodicNewsCheck<c- p>()</c-> <c- p>{</c->
   <c- kr>const</c-> registration <c- o>=</c-> await navigator<c- p>.</c->serviceWorker<c- p>.</c->ready<c- p>;</c->
   <c- k>try</c-> <c- p>{</c->
@@ -1572,280 +1585,348 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <c- p>}</c->
 <c- p>}</c->
 </pre>
-   <p>Reacting to a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event">periodicSync event</a> within a <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker">service worker</a>:</p>
+   <p>Reacting to a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event">periodicsync event</a> within a <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker">service worker</a>:</p>
 <pre class="lang-js highlight">self<c- p>.</c->addEventListener<c- p>(</c-><c- t>'periodicsync'</c-><c- p>,</c-> event <c- p>=></c-> <c- p>{</c->
   event<c- p>.</c->waitUntil<c- p>(</c->fetchAndCacheLatestNews<c- p>());</c->
 <c- p>});</c->
 </pre>
    <p>In the above example <code>fetchAndCacheLatestNews</code> is a developer-defined function is a developer-defined function that fetches the latest news articles from a server and stores them locally, for example using the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#cache" id="ref-for-cache">Cache</a></code> API, for offline consumption.</p>
    <h2 class="heading settled" data-level="2" id="concepts"><span class="secno">2. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
-   <p>The <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①">periodicSync event</a> is considered to run <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="in-the-background">in the background</dfn> if no <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client" id="ref-for-dfn-service-worker-client">service worker clients</a> whose <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type">frame type</a> is top-level or auxiliary exist for the origin of the corresponding service worker registration.</p>
-   <p>The user agent is considered to be <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online">online</a> if the user agent has established a network connection. A user agent MAY use a stricter definition of being <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online①">online</a>. Such a stricter definition MAY take into account the particular <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker①">service worker</a> or origin a <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration">periodicsync registration</a> is associated with.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodic-background-sync-opportunity">periodic Background Sync opportunity</dfn> allows periodic synchronization between the server and the web app, the exact interval of which is decided by the user agent. This can be requested through <code class="idl"><a data-link-type="idl" href="#dom-periodicsyncmanager-register" id="ref-for-dom-periodicsyncmanager-register">register()</a></code>.</p>
-   <h2 class="heading settled" data-level="3" id="constructs"><span class="secno">3. </span><span class="content">Constructs</span><a class="self-link" href="#constructs"></a></h2>
-    The user agent has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodicsync-processing-queue">periodicsync processing queue</dfn> (a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue" id="ref-for-parallel-queue">parallel queue</a>), initially the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue" id="ref-for-starting-a-new-parallel-queue">starting a new parallel queue</a>. 
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="list-of-periodicsync-registrations">list of periodicsync registrations</dfn> whose element type is a <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①">periodicsync registration</a>.</p>
-   <h3 class="heading settled" data-level="3.1" id="periodic-sync-registration"><span class="secno">3.1. </span><span class="content">PeriodicSync Registration</span><a class="self-link" href="#periodic-sync-registration"></a></h3>
-    A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodicsync-registration">periodicsync registration</dfn> is a tuple consisting of: 
-   <div>
-     A <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-service-worker-registration">service worker registration</dfn>, which is the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration①">service worker registration</a> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a> the <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager">PeriodicSyncManager</a></code> belongs to. 
-    <p>A <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-tag">tag</dfn>, which is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString">DOMString</a></code>. Within one <a data-link-type="dfn" href="#list-of-periodicsync-registrations" id="ref-for-list-of-periodicsync-registrations">list of periodicsync registrations</a> each <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration②">periodicsync registration</a> MUST have a unique <a data-link-type="dfn" href="#periodicsync-registration-tag" id="ref-for-periodicsync-registration-tag">tag</a>. Periodic Background Sync doesn’t share namespace with Background Sync, so an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin">origin</a> can have registrations of both types with the same tag.</p>
-    <p><dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-options">options</dfn>, which is a dictionary containing <a data-link-type="dfn" href="#options-mininterval" id="ref-for-options-mininterval">minInterval</a>.  Enclosing <a data-link-type="dfn" href="#periodicsync-registration-options" id="ref-for-periodicsync-registration-options">options</a> in a dictionary allows this spec to be extended with more <a data-link-type="dfn" href="#periodicsync-registration-options" id="ref-for-periodicsync-registration-options①">options</a> in the future without adversely affecting existing usage.</p>
-    <div><dfn class="dfn-paneled" data-dfn-for="options" data-dfn-type="dfn" data-noexport id="options-mininterval">minInterval</dfn> (a long long), which is used to specify the minimum interval, in milliseconds, at which the periodic synchronization should happen. <a data-link-type="dfn" href="#options-mininterval" id="ref-for-options-mininterval①">minInterval</a> is a suggestion to the user agent. The actual interval at which <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②">periodicSync events</a> are fired MUST be greater than or equal to this.</div>
-    <p>A <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-time-to-fire">time to fire</dfn> (a timestamp), which is the soonest time <a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire"> calculated</a> by the user agent at which it is appropriate to fire the next <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event③">periodicSync event</a> for the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration③">periodicsync registration</a>.</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-count-of-retries">count of retries</dfn> (a number), which is the number of retries attempted for the most recent <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event④">periodicSync event</a> for the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration④">periodicsync registration</a>.</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-registration-state">registration state</dfn>, which is one of <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-pending">pending</dfn>, <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-firing">firing</dfn>, or <dfn class="dfn-paneled" data-dfn-for="periodicsync registration" data-dfn-type="dfn" data-noexport id="periodicsync-registration-reregisteredwhilefiring">reregisteredWhileFiring</dfn>. It is initially set to <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending">pending</a>.</p>
-   </div>
-   <h3 class="heading settled" data-level="3.2" id="constants"><span class="secno">3.2. </span><span class="content">Constants</span><a class="self-link" href="#constants"></a></h3>
-    As recommended in <a href="#privacy">§ 4 Privacy Considerations</a> and <a href="#resources">§ 5 Resource Usage</a>, the user agent SHOULD also define: 
+   <p>When a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①">periodicsync event</a> is fired for a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration">periodic sync registration</a> <var>registration</var>, it is considered to run <dfn class="dfn-paneled" data-dfn-for="periodicsync event" data-dfn-type="dfn" data-noexport id="periodicsync-event-in-the-background">in the background</dfn> if no <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client" id="ref-for-dfn-service-worker-client">service worker clients</a> whose <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type">frame type</a> is "<code>top-level</code>", "<code>auxiliary</code>" or "<code>nested</code>" exist for the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin">origin</a> of the <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration">service worker registration</a> associated with <var>registration</var>.</p>
+   <h2 class="heading settled" data-level="3" id="extensions-to-service-worker-registration"><span class="secno">3. </span><span class="content">Extensions to service worker registration</span><a class="self-link" href="#extensions-to-service-worker-registration"></a></h2>
+    A <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration">service worker registration</a> additionally has: 
    <ul>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="minimum-interval-for-any-origin">minimum interval for any origin</dfn>, a long long, that represents the minimum gap between <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑤">periodicSync events</a> for any given origin, and,</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="active-periodic-sync-registrations">Active periodic sync registrations</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a>), where each key is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString">DOMString</a></code>, and each item is a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①">periodic sync registration</a>.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="minimum-interval-across-origins">minimum interval across origins</dfn>, a long long, that represents the minimum gap between <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑥">periodicSync events</a> across all origins.</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodic-sync-processing-queue">Periodic sync processing queue</dfn>, initially the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue" id="ref-for-starting-a-new-parallel-queue">starting a new parallel queue</a>.</p>
    </ul>
-   <p>The user agent MAY define a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="maximum-number-of-retries">maximum number of retries</dfn>, a number, allowed for each <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑦">periodicSync event</a>. In choosing this, the user agent SHOULD ensure that the time needed to attempt the <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries">maximum number of retries</a> is an order of magnitude smaller than the <a data-link-type="dfn" href="#minimum-interval-for-any-origin" id="ref-for-minimum-interval-for-any-origin">minimum interval for any origin</a>.</p>
-   <h3 class="heading settled" data-level="3.3" id="global-state"><span class="secno">3.3. </span><span class="content">Global State</span><a class="self-link" href="#global-state"></a></h3>
-    A user agent SHOULD keep track of the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="time the last periodicSync event was fired" data-noexport id="time-the-last-periodicsync-event-was-fired">time the last <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑧">periodicSync event</a> was fired</dfn>, a timestamp representing the time a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑨">periodicSync event</a> was fired for any <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration⑤">periodicsync registration</a>. 
-   <h2 class="heading settled" data-level="4" id="privacy"><span class="secno">4. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
-   <h3 class="heading settled" data-level="4.1" id="permission"><span class="secno">4.1. </span><span class="content">Permission</span><a class="self-link" href="#permission"></a></h3>
-    Periodic Background Sync is only available if the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionstate" id="ref-for-enumdef-permissionstate">PermissionState</a></code> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name">name</a></code> <code>"periodic-background-sync"</code> is <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted">granted</a></code>. In addition, user agents SHOULD offer a way for the user to disable Periodic Background Sync. 
-   <h3 class="heading settled" data-level="4.2" id="location-tracking"><span class="secno">4.2. </span><span class="content">Location Tracking</span><a class="self-link" href="#location-tracking"></a></h3>
-    Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⓪">periodicSync event</a> while <a data-link-type="dfn" href="#in-the-background" id="ref-for-in-the-background">in the background</a> may reveal the client’s IP address to the server after the user has left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①①">periodicSync event</a>s, to reduce the amount of time the user’s location can be tracked by the website. Further, the user agent SHOULD limit persistent location tracking by capping the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①②">periodicSync event</a>s, both for an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①">origin</a>, and across <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin②">origins</a>. 
-   <h3 class="heading settled" data-level="4.3" id="history-leaking"><span class="secno">4.3. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
-    Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①③">periodicSync event</a> while <a data-link-type="dfn" href="#in-the-background" id="ref-for-in-the-background①">in the background</a> may reveal something about the client’s navigation history to middleboxes on networks different from the one used to create the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration⑥">periodicsync registration</a>. For instance, the client might visit site https://example.com, which registers a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①④">periodicSync event</a>, but based on the implementation, might not fire until after the user has navigated away from the page and changed networks. Middleboxes on the new network may see the fetch requests that the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑤">periodicSync event</a> makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request). To prevent this leakage of browsing history, the user agent MAY choose to only fire <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑥">periodicSync event</a>s on the network the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration⑦">periodicsync registration</a> was made on, with the understanding that it will reduce usability by not allowing synchronization opportunistically. 
-   <h2 class="heading settled" data-level="5" id="resources"><span class="secno">5. </span><span class="content">Resource Usage</span><a class="self-link" href="#resources"></a></h2>
+   <h2 class="heading settled" data-level="4" id="constructs"><span class="secno">4. </span><span class="content">Constructs</span><a class="self-link" href="#constructs"></a></h2>
+   <h3 class="heading settled" data-level="4.1" id="periodic-sync-registration-construct"><span class="secno">4.1. </span><span class="content">Periodic sync registration</span><a class="self-link" href="#periodic-sync-registration-construct"></a></h3>
+    A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodic-sync-registration">periodic sync registration</dfn> consists of: 
+   <div>
+     A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-service-worker-registration">service worker registration</dfn>, which is a <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration①">service worker registration</a>. 
+    <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-tag">tag</dfn>, which is a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①">DOMString</a></code>.</p>
+    <p class="note" role="note"><span>Note:</span> Periodic Background Sync doesn’t share namespace with Background Sync, so an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①">origin</a> can have registrations of both types with the same tag.</p>
+    <p><dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-minimum-interval">minimum interval</dfn> (a long long), which is used to specify the minimum interval, in milliseconds, at which the periodic synchronization should happen. <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval">minimum interval</a> is a suggestion to the user agent.</p>
+    <p class="note" role="note"><span>Note:</span> The actual interval at which <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②">periodicsync events</a> are fired MUST be greater than or equal to this.</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-time-to-fire">time to fire</dfn> (a timestamp), which is the soonest time <a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire"> calculated</a> by the user agent at which it is appropriate to fire the next <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event③">periodicsync event</a> for the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration②">periodic sync registration</a>.</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-state">state</dfn>, which is one of "<code>pending</code>", "<code>firing</code>", "<code>suspended</code>" or "<code>reregistered-while-firing</code>". It is initially set to "<code>pending</code>".</p>
+   </div>
+   <h3 class="heading settled" data-level="4.2" id="periodic-sync-scheduler-construct"><span class="secno">4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler">Periodic Sync Scheduler</dfn></span><a class="self-link" href="#periodic-sync-scheduler-construct"></a></h3>
+    The <a data-link-type="dfn" href="#periodic-sync-scheduler" id="ref-for-periodic-sync-scheduler">periodic sync scheduler</a> is responsible for scheduling firing of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event④">periodicsync events</a>.
+In response to these triggers, the scheduler either schedules delayed processing to fire a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑤">periodicsync event</a> at the appropriate time in the future, or cancels such scheduling. 
+   <div>
+     The scheduler maintains: 
+    <ul>
+     <li data-md>
+      <p>The <dfn class="dfn-paneled" data-dfn-for="periodic sync scheduler" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler-time-of-last-fire">time of last fire</dfn>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a>, where each key is an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin②">origin</a>, and each item is a timestamp. The keys of this map are the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin③">origins</a> associated with the <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration①">service worker registrations</a> of <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations">active periodic sync registrations</a>. This is initially an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a>.</p>
+     <li data-md>
+      <p><dfn class="dfn-paneled" data-dfn-for="periodic sync scheduler" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler-effective-minimum-interval">Effective minimum interval</dfn>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">map</a>, where each key is an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin④">origin</a>, and each item is a long long, representing a time interval. The keys of this map are the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑤">origins</a> associated with the <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration②">service worker registrations</a> of <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①">active periodic sync registrations</a>. This is initially an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a>.</p>
+    </ul>
+   </div>
+   <p>The scheduler <a data-link-type="dfn" href="#process-periodic-sync-registrations" id="ref-for-process-periodic-sync-registrations">processes periodic sync registrations</a>.</p>
+   <p class="note" role="note"><span>Note:</span> Browsers may suspend this processing loop when there are no <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations②">active periodic sync registrations</a> to conserve resources.</p>
+   <h3 class="heading settled" data-level="4.3" id="constants"><span class="secno">4.3. </span><span class="content">Constants</span><a class="self-link" href="#constants"></a></h3>
+    As recommended in <a href="#privacy">§ 5 Privacy Considerations</a> and <a href="#resources">§ 6 Resource Usage</a>, the user agent SHOULD also define: 
+   <ul>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="minimum-periodic-sync-interval-for-any-origin">minimum periodic sync interval for any origin</dfn>, a long long, that represents the minimum gap between <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑥">periodicsync events</a> for any given origin, and,</p>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="minimum-periodic-sync-interval-across-origins">minimum periodic sync interval across origins</dfn>, a long long, that represents the minimum gap between <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑦">periodicsync events</a> across all origins.</p>
+   </ul>
+   <p><a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins">minimum periodic sync interval across origins</a> MUST be greater than or equal to <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin">minimum periodic sync interval for any origin</a>.
+If undefined, these are set to 43200000, which is twelve hours in milliseconds.</p>
+   <p class="note" role="note"><span>Note:</span> Two caps on frequency are needed because conforming to the cap enforced by <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin①">minimum periodic sync interval for any origin</a> for each origin can still cause the browser to fire <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑧">periodicsync events</a> very frequently. This can happen, for instance, when there are many <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration③">periodic sync registrations</a> for different origins. <a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins①">minimum periodic sync interval across origins</a> ensures there’s a global cap on how often these events are fired.</p>
+   <p>The user agent MAY define a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="maximum-number-of-retries">maximum number of retries</dfn>, a number, allowed for each <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑨">periodicsync event</a>. In choosing this, the user agent SHOULD ensure that the time needed to attempt the <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries">maximum number of retries</a> is an order of magnitude smaller than the <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin②">minimum periodic sync interval for any origin</a>. If undefined, this number is zero.</p>
+   <h2 class="heading settled" data-level="5" id="privacy"><span class="secno">5. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
+   <h3 class="heading settled" data-level="5.1" id="permission"><span class="secno">5.1. </span><span class="content">Permission</span><a class="self-link" href="#permission"></a></h3>
+    Periodic Background Sync is only available if the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionstate" id="ref-for-enumdef-permissionstate">PermissionState</a></code> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name">name</a></code> <code>"periodic-background-sync"</code> is <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted">granted</a></code>. In addition, user agents SHOULD offer a way for the user to disable Periodic Background Sync.
+When Periodic Background Sync is disabled, <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⓪">periodicsync events</a> MUST NOT be dispatched for the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration④">periodic sync registrations</a> affected by this permission. (See <a href="#responding-to-permission-revocation-algorithm">§ 7.3 Respond to permission revocation</a>). 
+   <h3 class="heading settled" data-level="5.2" id="location-tracking"><span class="secno">5.2. </span><span class="content">Location Tracking</span><a class="self-link" href="#location-tracking"></a></h3>
+    Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①①">periodicsync event</a> while <a data-link-type="dfn" href="#periodicsync-event-in-the-background" id="ref-for-periodicsync-event-in-the-background">in the background</a> may reveal the client’s IP address to the server after the user has left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①②">periodicsync event</a>s, to reduce the amount of time the user’s location can be tracked by the website. Further, the user agent SHOULD limit persistent location tracking by capping the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①③">periodicsync event</a>s, both for an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑥">origin</a>, and across <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑦">origins</a>. 
+   <h3 class="heading settled" data-level="5.3" id="history-leaking"><span class="secno">5.3. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
+    Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①④">periodicsync event</a> while <a data-link-type="dfn" href="#periodicsync-event-in-the-background" id="ref-for-periodicsync-event-in-the-background①">in the background</a> may reveal something about the client’s navigation history to middleboxes on networks different from the one used to create the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑤">periodic sync registration</a>. For instance, the client might visit site https://example.com, which registers a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑤">periodicsync event</a>, but based on the implementation, might not fire until after the user has navigated away from the page and changed networks. Middleboxes on the new network may see the fetch requests that the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑥">periodicsync event</a> makes. The fetch requests are HTTPS so the request contents will not be leaked but the destination of the fetch request and domain may be (via DNS lookups and IP address of the request). To prevent this leakage of browsing history, the user agent MAY choose to only fire <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑦">periodicsync events</a> on the network the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑥">periodic sync registration</a> was made on, with the understanding that it will reduce usability by not allowing synchronization opportunistically. 
+   <h2 class="heading settled" data-level="6" id="resources"><span class="secno">6. </span><span class="content">Resource Usage</span><a class="self-link" href="#resources"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <p>A website will most likely download resources from the network when processing a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑦">periodicsync event</a>. The underlying operating system may launch the user agent to dispatch these events, and may keep it awake for a pre-defined duration to allow processing of the events. Both cause battery drain.
+   <p>A website will most likely download resources from the network when processing a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑧">periodicsync event</a>. The underlying operating system may launch the user agent to dispatch these events, and may keep it awake for a pre-defined duration to allow processing of the events. Both cause battery drain.
 The user agent should cap the duration and frequency of these events to limit resource usage by websites when the user has navigated away.</p>
    <p>Large resources should be downloaded by registering a <a data-link-type="dfn" href="https://wicg.github.io/background-fetch/#background-fetch" id="ref-for-background-fetch">background fetch</a> via the <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/background-fetch/#backgroundfetchmanager" id="ref-for-backgroundfetchmanager">BackgroundFetchManager</a></code> interface.</p>
-   <p>In addition, the user agent should consider other factors such as user engagement with the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin③">origin</a>, and any user indications to temporarily reduce data consumption, such as a Data Saving Mode, to adjust the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑧">periodicSync events</a>.</p>
-   <h2 class="heading settled" data-level="6" id="algorithms"><span class="secno">6. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
-   <h3 class="heading settled" data-level="6.1" id="caculate-time-to-fire"><span class="secno">6.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="calculate-a-time-to-fire">Calculate a time to fire</dfn></span><a class="self-link" href="#caculate-time-to-fire"></a></h3>
-    This section describes how a user agent can calculate the <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire">time to fire</a> for a <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration⑧">periodicsync registration</a>, <var>registration</var>. The time interval between <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑨">periodicSync events</a> for <var>registration</var> MUST be greater than or equal to <var>registration</var>’s <a data-link-type="dfn" href="#options-mininterval" id="ref-for-options-mininterval②">minInterval</a> value. 
-   <p>The user agent MAY include factors such as user engagement with the origin to decide this time interval, allowing origins with high user engagement to update their web apps more often. The user agent SHOULD also ensure this time interval conforms to the caps asserted by <a data-link-type="dfn" href="#minimum-interval-for-any-origin" id="ref-for-minimum-interval-for-any-origin①">minimum interval for any origin</a> and the <a data-link-type="dfn" href="#minimum-interval-across-origins" id="ref-for-minimum-interval-across-origins">minimum interval across origins</a>.</p>
-   <p>The user agent MAY also decide to <a data-link-type="dfn" href="#retry" id="ref-for-retry">retry</a> each failed <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②⓪">periodicSync event</a> , with the count of retries capped to <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries①">maximum number of retries</a>.</p>
-   <p>A possible algorithm to calculate the <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire①">time to fire</a>, <var>timeToFire</var> for <var>registration</var> would involve running these steps:</p>
-   <ol>
-    <li data-md>
-     <p>If <a data-link-type="dfn" href="#periodicsync-registration-count-of-retries" id="ref-for-periodicsync-registration-count-of-retries">count of retries</a> for <var>registration</var> is 0, <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="calculate-the-time-to-fire-of-the-first-attempt-of">calculate the time to fire of the first attempt of</dfn> the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②①">periodicSync event</a> :</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>now</var>, a timestmap, represent the current time.</p>
-      <li data-md>
-       <p>Let <var>origin</var> represent <a data-link-type="dfn" href="#periodicsync-registration-service-worker-registration" id="ref-for-periodicsync-registration-service-worker-registration">service worker registration</a>'s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin④">origin</a>. Let <var>penalty</var> be a user agent defined penalty to account for the level of user engagement with the origin. Calculate <var>minimumIntervalForOrigin</var> as <var>penalty</var>*<a data-link-type="dfn" href="#minimum-interval-for-any-origin" id="ref-for-minimum-interval-for-any-origin②">minimum interval for any origin</a>.</p>
-      <li data-md>
-       <p>Set <var>delayForOrigin</var> to the multiple of <var>minimumIntervalForOrigin</var> greater than or equal to <a data-link-type="dfn" href="#options-mininterval" id="ref-for-options-mininterval③">minInterval</a>.</p>
-      <li data-md>
-       <p>Let <var>timeTillScheduledEventForOrigin</var>, a number, be the time till the next scheduled <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②②">periodicSync event</a> for <var>origin</var>, if any, null otherwise.</p>
-      <li data-md>
-       <p>If <var>timeTillScheduledEventForOrigin</var> is not null:</p>
-       <ol>
-        <li data-md>
-         <p>If <var>timeTillScheduledEventForOrigin</var> - <var>delayForOrigin</var> is greater than or equal to <var>minIntervalForOrigin</var>, abort these substeps.</p>
-        <li data-md>
-         <p>If <var>delayForOrigin</var> is less than or equal to <var>timeTillScheduledEventForOrigin</var>, set <var>delayForOrigin</var> to <var>timeTillScheduledEventForOrigin</var> and abort these substeps.</p>
-        <li data-md>
-         <p>If <var>delayForOrigin</var> is less than or equal to <var>timeTillScheduledEventForOrigin</var> + <var>minIntervalForOrigin</var>, set <var>delayForOrigin</var> to <var>timeTillScheduledEventForOrigin</var> + <var>minIntervalForOrigin</var>.</p>
-       </ol>
-      <li data-md>
-       <p>Let <var>timeSinceLastPeriodicSync</var> be null if <a data-link-type="dfn" href="#time-the-last-periodicsync-event-was-fired" id="ref-for-time-the-last-periodicsync-event-was-fired">time the last periodicSync event was fired</a> is null, else <var>now</var> - <a data-link-type="dfn" href="#time-the-last-periodicsync-event-was-fired" id="ref-for-time-the-last-periodicsync-event-was-fired①">time the last periodicSync event was fired</a>.</p>
-      <li data-md>
-       <p>If <var>timeSinceLastPeriodicSync</var> is null, set <var>timeToFire</var> to <var>delayForOrigin</var> + <var>now</var>.</p>
-      <li data-md>
-       <p>Else:</p>
-       <ol>
-        <li data-md>
-         <p>If <var>timeSinceLastPeriodicSync</var> is greater than equal to <a data-link-type="dfn" href="#minimum-interval-across-origins" id="ref-for-minimum-interval-across-origins①">minimum interval across origins</a>, set <var>timeToFire</var> to <var>delayForOrigin</var> + <var>now</var>.</p>
-        <li data-md>
-         <p>Else, set <var>timeTillNextAllowedPeriodicSync</var> to <a data-link-type="dfn" href="#minimum-interval-across-origins" id="ref-for-minimum-interval-across-origins②">minimum interval across origins</a> - <var>timeSinceLastPeriodicSync</var>. Set <var>timeToFire</var> to the maximum of <var>delayForOrigin</var> + <var>now</var>, and <var>timeTillNextAllowedPeriodicSync</var> + <var>now</var>.</p>
-       </ol>
-      <li data-md>
-       <p>Set the <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire②">time to fire</a> of <var>registration</var> to <var>timeToFire</var>.</p>
-     </ol>
-    <li data-md>
-     <p>Else:</p>
-     <ol>
-      <li data-md>
-       <p>Increment <a data-link-type="dfn" href="#periodicsync-registration-count-of-retries" id="ref-for-periodicsync-registration-count-of-retries①">count of retries</a>.</p>
-      <li data-md>
-       <p>If <a data-link-type="dfn" href="#periodicsync-registration-count-of-retries" id="ref-for-periodicsync-registration-count-of-retries②">count of retries</a> is greater than the <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries②">maximum number of retries</a> allowed, set <a data-link-type="dfn" href="#periodicsync-registration-count-of-retries" id="ref-for-periodicsync-registration-count-of-retries③">count of retries</a> to 0 and follow the steps to <a data-link-type="dfn" href="#calculate-the-time-to-fire-of-the-first-attempt-of" id="ref-for-calculate-the-time-to-fire-of-the-first-attempt-of">calculate the time to fire of the first attempt of</a> the periodicSync event.</p>
-      <li data-md>
-       <p>Else, Set the <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire③">time to fire</a> of <var>registration</var> to <var>now</var> + a small back-off that is exponentially proportional to <a data-link-type="dfn" href="#periodicsync-registration-count-of-retries" id="ref-for-periodicsync-registration-count-of-retries④">count of retries</a>.</p>
-     </ol>
-   </ol>
-   <h3 class="heading settled" data-level="6.2" id="schedule-delayed-processing"><span class="secno">6.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="schedule-processing">Schedule processing</dfn></span><a class="self-link" href="#schedule-delayed-processing"></a></h3>
-    To <a data-link-type="dfn" href="#schedule-processing" id="ref-for-schedule-processing">schedule processing</a> of a <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration⑨">periodicSync registration</a> <var>registration</var>, run the following steps: 
-   <ol>
-    <li data-md>
-     <p class="assertion">Assert: <var>registration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state">registration state</a> is <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending①">pending</a>.</p>
-    <li data-md>
-     <p>Schedule <a data-link-type="dfn" href="#fire-a-periodicsync-event" id="ref-for-fire-a-periodicsync-event">firing a periodicSync event</a> for <var>registration</var> as soon as the the device is online at or after <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire④">time to fire</a>.</p>
-   </ol>
-   <h2 class="heading settled" data-level="7" id="api-description"><span class="secno">7. </span><span class="content">API Description</span><a class="self-link" href="#api-description"></a></h2>
-   <h3 class="heading settled" data-level="7.1" id="extensions-to-serviceworkerglobalscope"><span class="secno">7.1. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code> interface</span><a class="self-link" href="#extensions-to-serviceworkerglobalscope"></a></h3>
+   <p>In addition, the user agent should consider other factors such as user engagement with the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑧">origin</a>, and any user indications to temporarily reduce data consumption, such as a Data Saving Mode, to adjust the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑨">periodicsync events</a>.</p>
+   <h2 class="heading settled" data-level="7" id="algorithms"><span class="secno">7. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+   <div class="algorithm" data-algorithm="Calculate a time to fire">
+    <h3 class="heading settled" data-level="7.1" id="caculate-time-to-fire"><span class="secno">7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="calculate-a-time-to-fire">Calculate a time to fire</dfn></span><a class="self-link" href="#caculate-time-to-fire"></a></h3>
+     This section describes how a user agent can calculate the <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire">time to fire</a> for a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑦">periodic sync registration</a>, <var>registration</var>. <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire①">time to fire</a> value MUST be updated in response to various triggers such as registration, unregistration, change in <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online">online</a> status, and completion of an attempt to fire a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②⓪">periodicsync event</a>. 
+    <p>Calculating the <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire②">time to fire</a> for <var>registration</var> involves running these steps:</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>now</var>, a timestamp, represent the current time.</p>
+     <li data-md>
+      <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑨">origin</a> associated with <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration③">service worker registration</a>.</p>
+     <li data-md>
+      <p>Let <var>effectiveMinimumIntervalForOrigin</var> be the greater of <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin③">minimum periodic sync interval for any origin</a> and <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval①">minimum interval</a>.</p>
+     <li data-md>
+      <p>Increment <var>effectiveMinimumIntervalForOrigin</var> by some user agent defined amount.</p>
+      <p class="note" role="note"><span>Note:</span> User agents can use this to delay synchronization due to the user’s engagement with <var>origin</var>.</p>
+     <li data-md>
+      <p>Set <a data-link-type="dfn" href="#periodic-sync-scheduler-effective-minimum-interval" id="ref-for-periodic-sync-scheduler-effective-minimum-interval">effective minimum interval</a> for <var>origin</var> to <var>effectiveMinimumIntervalForOrigin</var>.</p>
+     <li data-md>
+      <p>Set <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire③">time to fire</a> to <var>now</var> + <var>effectiveMinimumIntervalForOrigin</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="Process periodic sync registrations">
+    <h3 class="heading settled" data-level="7.2" id="process-periodic-sync-registrations-algorithm"><span class="secno">7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-periodic-sync-registrations">Process periodic sync registrations</dfn></span><a class="self-link" href="#process-periodic-sync-registrations-algorithm"></a></h3>
+     When the user agent starts, run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
+    <ol>
+     <li data-md>
+      <p>While true:</p>
+      <ol>
+       <li data-md>
+        <p>Wait for <a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins②">minimum periodic sync interval across origins</a>.</p>
+       <li data-md>
+        <p>Let <var>firedPeriodicSync</var> be false.</p>
+       <li data-md>
+        <p>While <var>firedPeriodicSync</var> is false:</p>
+        <ol>
+         <li data-md>
+          <p>Wait for some user agent defined amount of time.</p>
+          <p class="note" role="note"><span>Note:</span> This can be used to group synchronization for different <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑧">periodic sync registrations</a> into a single device wake-up.</p>
+         <li data-md>
+          <p>Wait until <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online①">online</a>.</p>
+         <li data-md>
+          <p>For each <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration②">service worker registration</a> <var>registration</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps">enqueue the following steps</a> to its <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue">periodic sync processing queue</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①⓪">origin</a> associated with <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration④">service worker registration</a>.</p>
+           <li data-md>
+            <p>If <a data-link-type="dfn" href="#periodic-sync-scheduler-time-of-last-fire" id="ref-for-periodic-sync-scheduler-time-of-last-fire">time of last fire</a> for <var>origin</var> + <a data-link-type="dfn" href="#periodic-sync-scheduler-effective-minimum-interval" id="ref-for-periodic-sync-scheduler-effective-minimum-interval①">effective minimum interval</a> for <var>origin</var> is greater than now, continue.</p>
+           <li data-md>
+            <p>For each <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑨">periodic sync registration</a> <var>periodicSyncRegistration</var> in <var>registration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations③">active periodic sync registrations</a>:</p>
+            <ol>
+             <li data-md>
+              <p>If <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state">state</a> is not "<code>pending</code>", continue.</p>
+             <li data-md>
+              <p>If <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire④">time to fire</a> is in the future, continue.</p>
+             <li data-md>
+              <p>Set <var>firedPeriodicSync</var> to true.</p>
+             <li data-md>
+              <p><a data-link-type="dfn" href="#fire-a-periodicsync-event" id="ref-for-fire-a-periodicsync-event">Fire a periodicsync event</a> for <var>periodicSyncRegistration</var>.</p>
+            </ol>
+          </ol>
+        </ol>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="Respond to permission revocation">
+    <h3 class="heading settled" data-level="7.3" id="responding-to-permission-revocation-algorithm"><span class="secno">7.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="respond-to-permission-revocation">Respond to permission revocation</dfn></span><a class="self-link" href="#responding-to-permission-revocation-algorithm"></a></h3>
+     To <a data-link-type="dfn" href="#respond-to-permission-revocation" id="ref-for-respond-to-permission-revocation">respond to revocation</a> of the permission with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name①">name</a></code> <code>"periodic-background-sync"</code> for <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①①">origin</a> <var>origin</var>, the user agent MUST <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps①">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue①">periodic sync processing queue</a>: 
+    <ol>
+     <li data-md>
+      <p>For each <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①⓪">periodic sync registration</a> <var>registration</var> in <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations④">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑤">service worker registration</a> is associated with the same <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①②">origin</a> as <var>origin</var>:</p>
+      <ol>
+       <li data-md>
+        <p>Remove <var>registration</var> from <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑤">active periodic sync registrations</a>.</p>
+      </ol>
+    </ol>
+   </div>
+   <h2 class="heading settled" data-level="8" id="api-description"><span class="secno">8. </span><span class="content">API Description</span><a class="self-link" href="#api-description"></a></h2>
+   <h3 class="heading settled" data-level="8.1" id="extensions-to-serviceworkerglobalscope"><span class="secno">8.1. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope">ServiceWorkerGlobalScope</a></code> interface</span><a class="self-link" href="#extensions-to-serviceworkerglobalscope"></a></h3>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope①"><c- g>ServiceWorkerGlobalScope</c-></a> {
     <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler"><c- n>EventHandler</c-></a> <dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export data-type="EventHandler" id="dom-serviceworkerglobalscope-onperiodicsync"><code><c- g>onperiodicsync</c-></code><a class="self-link" href="#dom-serviceworkerglobalscope-onperiodicsync"></a></dfn>;
 };
 </pre>
-   <h3 class="heading settled" data-level="7.2" id="extensions-to-serviceworkerregistration"><span class="secno">7.2. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration">ServiceWorkerRegistration</a></code> interface</span><a class="self-link" href="#extensions-to-serviceworkerregistration"></a></h3>
+   <h3 class="heading settled" data-level="8.2" id="extensions-to-serviceworkerregistration"><span class="secno">8.2. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration">ServiceWorkerRegistration</a></code> interface</span><a class="self-link" href="#extensions-to-serviceworkerregistration"></a></h3>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration①"><c- g>ServiceWorkerRegistration</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager①"><c- n>PeriodicSyncManager</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="PeriodicSyncManager" href="#dom-serviceworkerregistration-periodicsync" id="ref-for-dom-serviceworkerregistration-periodicsync"><c- g>periodicSync</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager"><c- n>PeriodicSyncManager</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="PeriodicSyncManager" href="#dom-serviceworkerregistration-periodicsync" id="ref-for-dom-serviceworkerregistration-periodicsync"><c- g>periodicSync</c-></a>;
 };
 </pre>
    <div>
-     A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration②">ServiceWorkerRegistration</a></code> has a <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="dfn" data-noexport id="serviceworkerregistration-periodic-sync-manager">periodic sync manager</dfn> (a <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager②">PeriodicSyncManager</a></code>), initially a new <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager③">PeriodicSyncManager</a></code> whose <code class="idl"><a data-link-type="idl" href="#dom-periodicsyncmanager-service-worker-registration" id="ref-for-dom-periodicsyncmanager-service-worker-registration">service worker registration</a></code> is the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object①">context object</a>'s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration②">service worker registration</a>. 
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export id="dom-serviceworkerregistration-periodicsync"><code>periodicSync</code></dfn> attribute’s getter must return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object②">context object</a>'s <a data-link-type="dfn" href="#serviceworkerregistration-periodic-sync-manager" id="ref-for-serviceworkerregistration-periodic-sync-manager">periodic sync manager</a>.</p>
+     A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration②">ServiceWorkerRegistration</a></code> has a <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="dfn" data-noexport id="serviceworkerregistration-periodic-sync-manager">periodic sync manager</dfn> (a <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager①">PeriodicSyncManager</a></code>). 
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export id="dom-serviceworkerregistration-periodicsync"><code>periodicSync</code></dfn> attribute’s getter must return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a>'s <a data-link-type="dfn" href="#serviceworkerregistration-periodic-sync-manager" id="ref-for-serviceworkerregistration-periodic-sync-manager">periodic sync manager</a>, initially a new <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager②">PeriodicSyncManager</a></code> whose <a data-link-type="dfn" href="#periodicsyncmanager-service-worker-registration" id="ref-for-periodicsyncmanager-service-worker-registration">service worker registration</a> is the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object①">context object</a>'s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration③">service worker registration</a>.</p>
    </div>
-   <h3 class="heading settled" data-level="7.3" id="periodicsyncmanager-interface"><span class="secno">7.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager④">PeriodicSyncManager</a></code> interface</span><a class="self-link" href="#periodicsyncmanager-interface"></a></h3>
+   <h3 class="heading settled" data-level="8.3" id="periodicsyncmanager-interface"><span class="secno">8.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager③">PeriodicSyncManager</a></code> interface</span><a class="self-link" href="#periodicsyncmanager-interface"></a></h3>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="periodicsyncmanager"><code><c- g>PeriodicSyncManager</c-></code></dfn> {
-    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-register" id="ref-for-dom-periodicsyncmanager-register①"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncManager/register(tag, options), PeriodicSyncManager/register(tag)" data-dfn-type="argument" data-export id="dom-periodicsyncmanager-register-tag-options-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-periodicsyncmanager-register-tag-options-tag"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundsyncoptions" id="ref-for-dictdef-backgroundsyncoptions"><c- n>BackgroundSyncOptions</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncManager/register(tag, options), PeriodicSyncManager/register(tag)" data-dfn-type="argument" data-export id="dom-periodicsyncmanager-register-tag-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-periodicsyncmanager-register-tag-options-options"></a></dfn>);
-    <c- b>Promise</c->&lt;<c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-gettags" id="ref-for-dom-periodicsyncmanager-gettags"><c- g>getTags</c-></a>();
-    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-unregister" id="ref-for-dom-periodicsyncmanager-unregister"><c- g>unregister</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncManager/unregister(tag)" data-dfn-type="argument" data-export id="dom-periodicsyncmanager-unregister-tag-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-periodicsyncmanager-unregister-tag-tag"></a></dfn>);
+    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-register" id="ref-for-dom-periodicsyncmanager-register"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncManager/register(tag, options), PeriodicSyncManager/register(tag)" data-dfn-type="argument" data-export id="dom-periodicsyncmanager-register-tag-options-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-periodicsyncmanager-register-tag-options-tag"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundsyncoptions" id="ref-for-dictdef-backgroundsyncoptions"><c- n>BackgroundSyncOptions</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncManager/register(tag, options), PeriodicSyncManager/register(tag)" data-dfn-type="argument" data-export id="dom-periodicsyncmanager-register-tag-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-periodicsyncmanager-register-tag-options-options"></a></dfn>);
+    <c- b>Promise</c->&lt;<c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-gettags" id="ref-for-dom-periodicsyncmanager-gettags"><c- g>getTags</c-></a>();
+    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-unregister" id="ref-for-dom-periodicsyncmanager-unregister"><c- g>unregister</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncManager/unregister(tag)" data-dfn-type="argument" data-export id="dom-periodicsyncmanager-unregister-tag-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-periodicsyncmanager-unregister-tag-tag"></a></dfn>);
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-backgroundsyncoptions"><code><c- g>BackgroundSyncOptions</c-></code></dfn> {
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-default="0" data-dfn-for="BackgroundSyncOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-backgroundsyncoptions-mininterval"><code><c- g>minInterval</c-></code><a class="self-link" href="#dom-backgroundsyncoptions-mininterval"></a></dfn> = 0;
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑤">PeriodicSyncManager</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="attribute" data-export id="dom-periodicsyncmanager-service-worker-registration"><code>service worker registration</code></dfn> (a <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration③">service worker registration</a>).</p>
-   <p>The <code><dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="method" data-export data-lt="register(tag, options)|register(tag)" id="dom-periodicsyncmanager-register" title="register(tag, options)"><code>register(<var>tag</var>, <var>options</var>)</code></dfn></code> method, when invoked, MUST return <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> <var>promise</var> and run the following steps:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑥">PeriodicSyncManager</a></code>'s associated <code class="idl"><a data-link-type="idl" href="#dom-periodicsyncmanager-service-worker-registration" id="ref-for-dom-periodicsyncmanager-service-worker-registration①">service worker registration</a></code>.</p>
-    <li data-md>
-     <p>If <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-active-worker" id="ref-for-dfn-active-worker">active worker</a> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort these steps.</p>
-    <li data-md>
-     <p>Else, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodicsync-processing-queue" id="ref-for-periodicsync-processing-queue">periodicsync processing queue</a>:</p>
-     <ol>
-      <li data-md>
-       <p>If the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionstate" id="ref-for-enumdef-permissionstate①">PermissionState</a></code> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor①">PermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name①">name</a></code> <code>"periodic-background-sync"</code> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①">granted</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject①">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code> and abort these steps.</p>
-      <li data-md>
-       <p>Let <var>isBackground</var>, a boolean, be true.</p>
-      <li data-md>
-       <p>For each <var>client</var> in the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client" id="ref-for-dfn-service-worker-client①">service worker clients</a> for the <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑤">origin</a>:</p>
-      <li data-md>
-       <p>If <var>client</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type①">frame type</a> is top-level or auxillary, set <var>isBackground</var> to false.</p>
-      <li data-md>
-       <p>If <var>isBackground</var> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject②">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror" id="ref-for-invalidaccesserror">InvalidAccessError</a></code> and abort these steps.</p>
-      <li data-md>
-       <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①⓪">periodicsync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-periodicsync-registrations" id="ref-for-list-of-periodicsync-registrations①">list of periodicsync registrations</a> whose <a data-link-type="dfn" href="#periodicsync-registration-tag" id="ref-for-periodicsync-registration-tag①">tag</a> equals <var>tag</var> if it exists, else null.</p>
-      <li data-md>
-       <p>If <var>currentRegistration</var> is null:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>newRegistration</var> be a new <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①①">periodicsync registration</a>.</p>
-        <li data-md>
-         <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-tag" id="ref-for-periodicsync-registration-tag②">tag</a> to <var>tag</var>.</p>
-        <li data-md>
-         <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-options" id="ref-for-periodicsync-registration-options②">options</a> to <var>options</var>.</p>
-        <li data-md>
-         <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state①">registration state</a> to <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending②">pending</a>.</p>
-        <li data-md>
-         <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-service-worker-registration" id="ref-for-periodicsync-registration-service-worker-registration①">service worker registration</a> to <var>serviceWorkerRegistration</var>.</p>
-        <li data-md>
-         <p>Add <var>newRegistration</var> to <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-periodicsync-registrations" id="ref-for-list-of-periodicsync-registrations②">list of periodicsync registrations</a>.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire①">Calculate a time to fire</a> for <var>newRegistration</var>.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="#schedule-processing" id="ref-for-schedule-processing①">Schedule processing</a> for <var>registration</var>.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve">Resolve</a> <var>promise</var>.</p>
-       </ol>
-      <li data-md>
-       <p>Else:</p>
-       <ol>
-        <li data-md>
-         <p>If the <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-options" id="ref-for-periodicsync-registration-options③">options</a> is different from <var>options</var>:</p>
-         <ol>
-          <li data-md>
-           <p>Set <var>currentRegistration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-options" id="ref-for-periodicsync-registration-options④">options</a> to <var>options</var>.</p>
-          <li data-md>
-           <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire②">Calculate a time to fire</a> for <var>newRegistration</var>.</p>
-          <li data-md>
-           <p>Set <var>currentRegistration</var>’s associated <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state②">registration state</a> to <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending③">pending</a>.</p>
-         </ol>
-        <li data-md>
-         <p>Else, if <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state③">registration state</a> is <a data-link-type="dfn" href="#periodicsync-registration-firing" id="ref-for-periodicsync-registration-firing">firing</a>, set <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state④">registration state</a> to <a data-link-type="dfn" href="#periodicsync-registration-reregisteredwhilefiring" id="ref-for-periodicsync-registration-reregisteredwhilefiring">reregisteredWhileFiring</a>.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve①">Resolve</a> <var>promise</var>.</p>
-       </ol>
-     </ol>
-   </ol>
-   <p>The <code><dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="method" data-export id="dom-periodicsyncmanager-gettags" title="getTags()"><code>getTags()</code></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> <var>promise</var> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps①">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodicsync-processing-queue" id="ref-for-periodicsync-processing-queue①">periodicsync processing queue</a>:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑦">PeriodicSyncManager</a></code>'s associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration④">service worker registration</a>.</p>
-    <li data-md>
-     <p>Let <var>currentTags</var> be a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a>.</p>
-    <li data-md>
-     <p>For each <var>registration</var> of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-periodicsync-registrations" id="ref-for-list-of-periodicsync-registrations③">list of periodicsync registrations</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-tag" id="ref-for-periodicsync-registration-tag③">tag</a> to <var>currentTags</var>.</p>
-    <li data-md>
-     <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve②">Resolve</a> <var>promise</var> with <var>currentTags</var>.</p>
-   </ol>
-   <p>The <code><dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="method" data-export id="dom-periodicsyncmanager-unregister" title="unregister(tag)"><code>unregister(tag)</code></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> <var>promise</var> and run the following steps:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑧">PeriodicSyncManager</a></code>'s associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑤">service worker registration</a>.</p>
-    <li data-md>
-     <p>If <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-active-worker" id="ref-for-dfn-active-worker①">active worker</a> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject③">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code> and abort these steps.</p>
-    <li data-md>
-     <p>Else, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps②">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodicsync-processing-queue" id="ref-for-periodicsync-processing-queue②">periodicsync processing queue</a>:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①②">periodicsync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-periodicsync-registrations" id="ref-for-list-of-periodicsync-registrations④">list of periodicsync registrations</a> whose <a data-link-type="dfn" href="#periodicsync-registration-tag" id="ref-for-periodicsync-registration-tag④">tag</a> equals <var>tag</var> if it exists, else null.</p>
-      <li data-md>
-       <p>If <var>currentRegistration</var> is not null, remove <var>registration</var> from <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-periodicsync-registrations" id="ref-for-list-of-periodicsync-registrations⑤">list of periodicsync registrations</a>.</p>
-      <li data-md>
-       <p>Resolve <var>promise</var>.</p>
-     </ol>
-   </ol>
-   <h3 class="heading settled" data-level="7.4" id="periodicSync-event"><span class="secno">7.4. </span><span class="content">The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodicsync-event">periodicSync event</dfn></span><a class="self-link" href="#periodicSync-event"></a></h3>
+   <div> A <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager④">PeriodicSyncManager</a></code> has a <dfn class="dfn-paneled" data-dfn-for="PeriodicSyncManager" data-dfn-type="dfn" data-noexport id="periodicsyncmanager-service-worker-registration">service worker registration</dfn> (a <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration④">service worker registration</a>). </div>
+   <div class="algorithm" data-algorithm="register(tag, options)">
+     The <code><dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="method" data-export data-lt="register(tag, options)|register(tag)" id="dom-periodicsyncmanager-register" title="register(tag, options)"><code>register(<var>tag</var>, <var>options</var>)</code></dfn></code> method, when invoked, MUST return <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise">a new promise</a> <var>promise</var> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps②">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue②">periodic sync processing queue</a>: 
+    <ol>
+     <li data-md>
+      <p>Let <var>serviceWorkerRegistration</var> be the <a data-link-type="dfn" href="#periodicsyncmanager-service-worker-registration" id="ref-for-periodicsyncmanager-service-worker-registration①">service worker registration</a> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object②">context object</a>'s <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑤">PeriodicSyncManager</a></code>.</p>
+     <li data-md>
+      <p>If <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-active-worker" id="ref-for-dfn-active-worker">active worker</a> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort these steps.</p>
+     <li data-md>
+      <p>If the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionstate" id="ref-for-enumdef-permissionstate①">PermissionState</a></code> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor①">PermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name②">name</a></code> <code>"periodic-background-sync"</code> is not <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted①">granted</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject①">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code> and abort these steps.</p>
+     <li data-md>
+      <p>Let <var>isBackground</var>, a boolean, be true.</p>
+     <li data-md>
+      <p>For each <var>client</var> in the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client" id="ref-for-dfn-service-worker-client①">service worker clients</a> for the <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①③">origin</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>client</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type①">frame type</a> is "<code>top-level</code>" or "<code>auxiliary</code>", set <var>isBackground</var> to false.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>isBackground</var> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject②">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror" id="ref-for-invalidaccesserror">InvalidAccessError</a></code> and abort these steps.</p>
+     <li data-md>
+      <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①①">periodic sync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑥">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag">tag</a> equals <var>tag</var> if it exists, else null.</p>
+     <li data-md>
+      <p>If <var>currentRegistration</var> is null:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>newRegistration</var> be a new <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①②">periodic sync registration</a>.</p>
+       <li data-md>
+        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag①">tag</a> to <var>tag</var>.</p>
+       <li data-md>
+        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval②">minimum interval</a> to <var>options</var>.<var>minInterval</var>.</p>
+       <li data-md>
+        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state①">state</a> to "<code>pending</code>".</p>
+       <li data-md>
+        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑥">service worker registration</a> to <var>serviceWorkerRegistration</var>.</p>
+       <li data-md>
+        <p>Add <var>newRegistration</var> to <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑦">active periodic sync registrations</a>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire①">Calculate a time to fire</a> for <var>newRegistration</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve">Resolve</a> <var>promise</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Else:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval③">minimum interval</a> is different to <var>options</var>.<var>minInterval</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval④">minimum interval</a> <var>options</var>.<var>minInterval</var>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire②">Calculate a time to fire</a> for <var>newRegistration</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Else, if <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state②">state</a> is "<code>firing</code>", set <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state③">state</a> to "<code>reregistered-while-firing</code>".</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve①">Resolve</a> <var>promise</var>.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="getTags()">
+     The <code><dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="method" data-export id="dom-periodicsyncmanager-gettags" title="getTags()"><code>getTags()</code></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> <var>promise</var> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps③">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue③">periodic sync processing queue</a>: 
+    <ol>
+     <li data-md>
+      <p>Let <var>serviceWorkerRegistration</var> be the <a data-link-type="dfn" href="#periodicsyncmanager-service-worker-registration" id="ref-for-periodicsyncmanager-service-worker-registration②">service worker registration</a> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object③">context object</a>'s <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑥">PeriodicSyncManager</a></code>.</p>
+     <li data-md>
+      <p>Let <var>currentTags</var> be a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a>.</p>
+     <li data-md>
+      <p>For each <var>registration</var> of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑧">active periodic sync registrations</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag②">tag</a> to <var>currentTags</var>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve②">Resolve</a> <var>promise</var> with <var>currentTags</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="unregister(tag)">
+     The <code><dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncManager" data-dfn-type="method" data-export id="dom-periodicsyncmanager-unregister" title="unregister(tag)"><code>unregister(<var>tag</var>)</code></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a> <var>promise</var> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps④">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue④">periodic sync processing queue</a>: 
+    <ol>
+     <li data-md>
+      <p>Let <var>serviceWorkerRegistration</var> be the <a data-link-type="dfn" href="#periodicsyncmanager-service-worker-registration" id="ref-for-periodicsyncmanager-service-worker-registration③">service worker registration</a> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object④">context object</a>'s <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑦">PeriodicSyncManager</a></code>.</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①③">periodic sync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑨">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag③">tag</a> equals <var>tag</var> if it exists, else null.</p>
+       <li data-md>
+        <p>If <var>currentRegistration</var> is not null, remove <var>currentRegistration</var> from <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①⓪">active periodic sync registrations</a>.</p>
+       <li data-md>
+        <p>Resolve <var>promise</var>.</p>
+      </ol>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="8.4" id="periodicsync-event-interface"><span class="secno">8.4. </span><span class="content">The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodicsync-event">periodicsync event</dfn></span><a class="self-link" href="#periodicsync-event-interface"></a></h3>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-periodicsynceventinit"><code><c- g>PeriodicSyncEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit"><c- n>ExtendableEventInit</c-></a> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncEventInit" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-periodicsynceventinit-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-periodicsynceventinit-tag"></a></dfn>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncEventInit" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-periodicsynceventinit-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-periodicsynceventinit-tag"></a></dfn>;
 };
 
 [
-    <dfn class="idl-code" data-dfn-for="PeriodicSyncEvent" data-dfn-type="constructor" data-export data-lt="PeriodicSyncEvent(type, init)" id="dom-periodicsyncevent-periodicsyncevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-periodicsyncevent-periodicsyncevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncEvent/PeriodicSyncEvent(type, init)" data-dfn-type="argument" data-export id="dom-periodicsyncevent-periodicsyncevent-type-init-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-periodicsyncevent-periodicsyncevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-periodicsynceventinit" id="ref-for-dictdef-periodicsynceventinit"><c- n>PeriodicSyncEventInit</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncEvent/PeriodicSyncEvent(type, init)" data-dfn-type="argument" data-export id="dom-periodicsyncevent-periodicsyncevent-type-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-periodicsyncevent-periodicsyncevent-type-init-init"></a></dfn>),
+    <dfn class="idl-code" data-dfn-for="PeriodicSyncEvent" data-dfn-type="constructor" data-export data-lt="PeriodicSyncEvent(type, init)" id="dom-periodicsyncevent-periodicsyncevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-periodicsyncevent-periodicsyncevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncEvent/PeriodicSyncEvent(type, init)" data-dfn-type="argument" data-export id="dom-periodicsyncevent-periodicsyncevent-type-init-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-periodicsyncevent-periodicsyncevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-periodicsynceventinit" id="ref-for-dictdef-periodicsynceventinit"><c- n>PeriodicSyncEventInit</c-></a> <dfn class="idl-code" data-dfn-for="PeriodicSyncEvent/PeriodicSyncEvent(type, init)" data-dfn-type="argument" data-export id="dom-periodicsyncevent-periodicsyncevent-type-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-periodicsyncevent-periodicsyncevent-type-init-init"></a></dfn>),
     <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->
 ] <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="periodicsyncevent"><code><c- g>PeriodicSyncEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent"><c- n>ExtendableEvent</c-></a> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-periodicsyncevent-tag"><code><c- g>tag</c-></code></dfn>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-periodicsyncevent-tag" id="ref-for-dom-periodicsyncevent-tag"><c- g>tag</c-></a>;
   };
 </pre>
-   <p>The <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent">PeriodicSyncEvent</a></code> interface represents a <a data-link-type="dfn" href="#periodicsync-registration-firing" id="ref-for-periodicsync-registration-firing①">firing</a> <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①③">periodicsync registration</a>.</p>
-   <h4 class="heading settled" data-level="7.4.1" id="firing-periodicsync-events"><span class="secno">7.4.1. </span><span class="content">Firing periodicSync events</span><a class="self-link" href="#firing-periodicsync-events"></a></h4>
-    Whenever the user agent changes to <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online②">online</a>, it SHOULD <a data-link-type="dfn" href="#fire-a-periodicsync-event" id="ref-for-fire-a-periodicsync-event①">fire a periodicSync event</a> for each <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①④">periodicsync registration</a> whose <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state⑤">registration state</a> is <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending④">pending</a> and <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire⑤">time to fire</a> is now or in the past. 
-   <h4 class="heading settled" data-level="7.4.2" id="firing-a-periodicsync-event"><span class="secno">7.4.2. </span><span class="content"><a data-link-type="dfn" href="#fire-a-periodicsync-event" id="ref-for-fire-a-periodicsync-event②">Fire a periodicSync event</a></span><a class="self-link" href="#firing-a-periodicsync-event"></a></h4>
-    The user agent will fire a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②③">periodicSync event</a> for a <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①⑤">periodicsync registration</a> as soon as network connectivity is available, at or after the <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire⑥">time to fire</a> of the <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①⑥">periodicsync registration</a>.
-If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②④">periodicSync event</a> fails, the user agent MAY <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="retry">retry</dfn> it one or more times at a time of its choosing, based on some user agent defined heuristics. 
-   <p>A user agent MAY impose a time limit on the lifetime extension and execution time of a <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent①">PeriodicSyncEvent</a></code> which is stricter than the time limit imposed for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent①">ExtendableEvent</a></code>s in general. In particular, any retries of the <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent②">PeriodicSyncEvent</a></code> MAY have a significantly shortened time limit.</p>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fire-a-periodicsync-event">fire a periodicSync event</dfn> for a <a data-link-type="dfn" href="#periodicsync-registration" id="ref-for-periodicsync-registration①⑦">periodicsync registration</a> <var>registration</var>, the user agent MUST <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps③">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodicsync-processing-queue" id="ref-for-periodicsync-processing-queue③">periodicsync processing queue</a>:</p>
+   <div> A <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent">PeriodicSyncEvent</a></code> has a <dfn class="dfn-paneled" data-dfn-for="PeriodicSyncEvent" data-dfn-type="dfn" data-noexport id="periodicsyncevent-tag">tag</dfn> (a <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag④">tag</a>).
+  The <dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncEvent" data-dfn-type="attribute" data-export id="dom-periodicsyncevent-tag"><code>tag</code></dfn> attribute must return the value it was initialized to. </div>
+   <h4 class="heading settled" data-level="8.4.1" id="firing-a-periodicsync-event"><span class="secno">8.4.1. </span><span class="content"><a data-link-type="dfn" href="#fire-a-periodicsync-event" id="ref-for-fire-a-periodicsync-event①">Fire a periodicsync event</a></span><a class="self-link" href="#firing-a-periodicsync-event"></a></h4>
+    Note: A user agent MAY impose a time limit on the lifetime extension and execution time of a <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent①">PeriodicSyncEvent</a></code> which is stricter than the time limit imposed for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent①">ExtendableEvent</a></code>s in general. In particular, any retries of the <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent②">PeriodicSyncEvent</a></code> MAY have a significantly shortened time limit. 
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fire-a-periodicsync-event">fire a periodicsync event</dfn> for a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①④">periodic sync registration</a> <var>registration</var>, the user agent MUST run the following steps:</p>
    <ol>
     <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state⑥">registration state</a> is <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending⑤">pending</a>.</p>
+     <p>Let <var>serviceWorkerRegistration</var> be <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑦">service worker registration</a>.</p>
     <li data-md>
-     <p>Let <var>serviceWorkerRegistration</var> be <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-service-worker-registration" id="ref-for-periodicsync-registration-service-worker-registration②">service worker registration</a>.</p>
+     <p>If <var>registration</var> is no longer part of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①①">active periodic sync registrations</a>, abort these steps.</p>
     <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-time-to-fire" id="ref-for-periodicsync-registration-time-to-fire⑦">time to fire</a> is equal to the current time or in the past.</p>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state④">state</a> is "<code>pending</code>".</p>
     <li data-md>
-     <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-registration-state" id="ref-for-periodicsync-registration-registration-state⑦">registration state</a> to <a data-link-type="dfn" href="#periodicsync-registration-firing" id="ref-for-periodicsync-registration-firing②">firing</a>.</p>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire⑤">time to fire</a> is equal to the current time or in the past.</p>
     <li data-md>
-     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">In parallel</a>, <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#fire-functional-event" id="ref-for-fire-functional-event">fire functional event</a> "<code>periodicSync</code>" using <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent③">PeriodicSyncEvent</a></code> on <var>serviceWorkerRegistration</var> with <code class="idl"><a data-link-type="idl" href="#dom-periodicsyncevent-tag" id="ref-for-dom-periodicsyncevent-tag">tag</a></code> set to <var>registration</var>’s <a data-link-type="dfn" href="#periodicsync-registration-tag" id="ref-for-periodicsync-registration-tag⑤">tag</a>. Let <var>dispatchedEvent</var>, an <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent②">ExtendableEvent</a></code>, represent the dispatched <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②⑤">periodicSync event</a>, and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps④">enqueue the following steps</a> on the <a data-link-type="dfn" href="#periodicsync-processing-queue" id="ref-for-periodicsync-processing-queue④">periodicsync processing queue</a>:</p>
+     <p>Let retryCount be 0.</p>
+    <li data-md>
+     <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state⑤">state</a> to "<code>firing</code>".</p>
+    <li data-md>
+     <p>While true:</p>
      <ol>
+      <li data-md>
+       <p>Let <var>continue</var> be false.</p>
+      <li data-md>
+       <p>Let <var>success</var> be false.</p>
+      <li data-md>
+       <p><a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#fire-functional-event" id="ref-for-fire-functional-event">Fire functional event</a> "<code>periodicsync</code>" using <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent③">PeriodicSyncEvent</a></code> on <var>serviceWorkerRegistration</var> with <a data-link-type="dfn" href="#periodicsyncevent-tag" id="ref-for-periodicsyncevent-tag">tag</a> set to <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag⑤">tag</a>. Let <var>dispatchedEvent</var>, an <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent②">ExtendableEvent</a></code>, represent the dispatched <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②①">periodicsync event</a> and run the following steps with <var>dispatchedEvent</var>:</p>
       <li data-md>
        <p>Let <var>waitUntilPromise</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#wait-for-all" id="ref-for-wait-for-all">waiting for all</a> of <var>dispatchedEvent</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises">extend lifetime promises</a>.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-fulfillment" id="ref-for-upon-fulfillment">Upon fulfillment</a> or <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-rejection" id="ref-for-upon-rejection">rejection</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#terminate-service-worker" id="ref-for-terminate-service-worker">termination</a> of the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker" id="ref-for-dfn-service-worker②">service worker</a> of <var>waitUntilPromise</var>, run the following steps:</p>
+       <p>React to the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-fulfillment" id="ref-for-upon-fulfillment">fulfillment</a> of <var>waitUntilPromise</var> with the following steps:</p>
        <ol>
         <li data-md>
-         <p>Set <var>registration</var>’s state to <a data-link-type="dfn" href="#periodicsync-registration-pending" id="ref-for-periodicsync-registration-pending⑥">pending</a>.</p>
+         <p>Set <var>success</var> to true.</p>
         <li data-md>
-         <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire③">Calculate a time to fire</a> for <var>registration</var>.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="#schedule-processing" id="ref-for-schedule-processing②">Schedule processing</a> for <var>registration</var>.</p>
+         <p>Set <var>continue</var> to true.</p>
        </ol>
+      <li data-md>
+       <p>React to rejection <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-rejection" id="ref-for-upon-rejection">rejection</a> of <var>waitUntilPromise</var> with the following steps:</p>
+       <ol>
+        <li data-md>
+         <p>Set <var>continue</var> to true.</p>
+       </ol>
+      <li data-md>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">In parallel</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Wait for <var>continue</var> to be true.</p>
+        <li data-md>
+         <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①④">origin</a> associated with <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑧">service worker registration</a>.</p>
+        <li data-md>
+         <p>If <var>success</var> is true, set <a data-link-type="dfn" href="#periodic-sync-scheduler-time-of-last-fire" id="ref-for-periodic-sync-scheduler-time-of-last-fire①">time of last fire</a> for key <var>origin</var> to the current time.</p>
+        <li data-md>
+         <p>If <var>success</var> is true or <var>retryCount</var> is greater than <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries①">maximum number of retries</a> or <var>registration</var>’s state is "<code>reregistered-while-firing</code>", then:</p>
+         <ol>
+          <li data-md>
+           <p>
+            Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state⑥">state</a> to "
+            <cod>pending`".</cod>
+           </p>
+          <li data-md>
+           <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire③">Calculate a time to fire</a> for <var>registration</var>.</p>
+          <li data-md>
+           <p>Abort these steps.</p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p>Increment <var>retryCount</var>.</p>
+      <li data-md>
+       <p>Wait for a small back-off time based on <var>retryCount</var>.</p>
      </ol>
    </ol>
   </main>
@@ -1998,83 +2079,75 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dictdef-backgroundsyncoptions">BackgroundSyncOptions</a><span>, in §7.3</span>
-   <li><a href="#calculate-a-time-to-fire">Calculate a time to fire</a><span>, in §6.1</span>
-   <li><a href="#calculate-the-time-to-fire-of-the-first-attempt-of">calculate the time to fire of the first attempt of</a><span>, in §6.1</span>
-   <li><a href="#periodicsync-registration-count-of-retries">count of retries</a><span>, in §3.1</span>
-   <li><a href="#fire-a-periodicsync-event">fire a periodicSync event</a><span>, in §7.4.2</span>
-   <li><a href="#periodicsync-registration-firing">firing</a><span>, in §3.1</span>
-   <li><a href="#dom-periodicsyncmanager-gettags">getTags()</a><span>, in §7.3</span>
-   <li><a href="#in-the-background">in the background</a><span>, in §2</span>
-   <li><a href="#list-of-periodicsync-registrations">list of periodicsync registrations</a><span>, in §3</span>
-   <li><a href="#maximum-number-of-retries">maximum number of retries</a><span>, in §3.2</span>
-   <li><a href="#minimum-interval-across-origins">minimum interval across origins</a><span>, in §3.2</span>
-   <li><a href="#minimum-interval-for-any-origin">minimum interval for any origin</a><span>, in §3.2</span>
-   <li>
-    minInterval
-    <ul>
-     <li><a href="#options-mininterval">dfn for options</a><span>, in §3.1</span>
-     <li><a href="#dom-backgroundsyncoptions-mininterval">dict-member for BackgroundSyncOptions</a><span>, in §7.3</span>
-    </ul>
-   <li><a href="#dom-serviceworkerglobalscope-onperiodicsync">onperiodicsync</a><span>, in §7.1</span>
-   <li><a href="#periodicsync-registration-options">options</a><span>, in §3.1</span>
-   <li><a href="#periodicsync-registration-pending">pending</a><span>, in §3.1</span>
-   <li><a href="#periodic-background-sync-opportunity">periodic Background Sync opportunity</a><span>, in §2</span>
-   <li><a href="#dom-serviceworkerregistration-periodicsync">periodicSync</a><span>, in §7.2</span>
-   <li><a href="#periodicsync-event">periodicSync event</a><span>, in §7.4</span>
-   <li><a href="#periodicsyncevent">PeriodicSyncEvent</a><span>, in §7.4</span>
-   <li><a href="#dictdef-periodicsynceventinit">PeriodicSyncEventInit</a><span>, in §7.4</span>
-   <li><a href="#dom-periodicsyncevent-periodicsyncevent">PeriodicSyncEvent(type, init)</a><span>, in §7.4</span>
-   <li><a href="#serviceworkerregistration-periodic-sync-manager">periodic sync manager</a><span>, in §7.2</span>
-   <li><a href="#periodicsyncmanager">PeriodicSyncManager</a><span>, in §7.3</span>
-   <li><a href="#periodicsync-processing-queue">periodicsync processing queue</a><span>, in §3</span>
-   <li><a href="#periodicsync-registration">periodicsync registration</a><span>, in §3.1</span>
-   <li><a href="#dom-periodicsyncmanager-register">register(tag)</a><span>, in §7.3</span>
-   <li><a href="#dom-periodicsyncmanager-register">register(tag, options)</a><span>, in §7.3</span>
-   <li><a href="#periodicsync-registration-registration-state">registration state</a><span>, in §3.1</span>
-   <li><a href="#periodicsync-registration-reregisteredwhilefiring">reregisteredWhileFiring</a><span>, in §3.1</span>
-   <li><a href="#retry">retry</a><span>, in §7.4.2</span>
-   <li><a href="#schedule-processing">Schedule processing</a><span>, in §6.2</span>
+   <li><a href="#active-periodic-sync-registrations">Active periodic sync registrations</a><span>, in §3</span>
+   <li><a href="#dictdef-backgroundsyncoptions">BackgroundSyncOptions</a><span>, in §8.3</span>
+   <li><a href="#calculate-a-time-to-fire">Calculate a time to fire</a><span>, in §7.1</span>
+   <li><a href="#periodic-sync-scheduler-effective-minimum-interval">Effective minimum interval</a><span>, in §4.2</span>
+   <li><a href="#fire-a-periodicsync-event">fire a periodicsync event</a><span>, in §8.4.1</span>
+   <li><a href="#dom-periodicsyncmanager-gettags">getTags()</a><span>, in §8.3</span>
+   <li><a href="#periodicsync-event-in-the-background">in the background</a><span>, in §2</span>
+   <li><a href="#maximum-number-of-retries">maximum number of retries</a><span>, in §4.3</span>
+   <li><a href="#periodic-sync-registration-minimum-interval">minimum interval</a><span>, in §4.1</span>
+   <li><a href="#minimum-periodic-sync-interval-across-origins">minimum periodic sync interval across origins</a><span>, in §4.3</span>
+   <li><a href="#minimum-periodic-sync-interval-for-any-origin">minimum periodic sync interval for any origin</a><span>, in §4.3</span>
+   <li><a href="#dom-backgroundsyncoptions-mininterval">minInterval</a><span>, in §8.3</span>
+   <li><a href="#dom-serviceworkerglobalscope-onperiodicsync">onperiodicsync</a><span>, in §8.1</span>
+   <li><a href="#dom-serviceworkerregistration-periodicsync">periodicSync</a><span>, in §8.2</span>
+   <li><a href="#periodicsync-event">periodicsync event</a><span>, in §8.4</span>
+   <li><a href="#periodicsyncevent">PeriodicSyncEvent</a><span>, in §8.4</span>
+   <li><a href="#dictdef-periodicsynceventinit">PeriodicSyncEventInit</a><span>, in §8.4</span>
+   <li><a href="#dom-periodicsyncevent-periodicsyncevent">PeriodicSyncEvent(type, init)</a><span>, in §8.4</span>
+   <li><a href="#periodicsyncmanager">PeriodicSyncManager</a><span>, in §8.3</span>
+   <li><a href="#serviceworkerregistration-periodic-sync-manager">periodic sync manager</a><span>, in §8.2</span>
+   <li><a href="#periodic-sync-processing-queue">Periodic sync processing queue</a><span>, in §3</span>
+   <li><a href="#periodic-sync-registration">periodic sync registration</a><span>, in §4.1</span>
+   <li><a href="#periodic-sync-scheduler">Periodic Sync Scheduler</a><span>, in §4.2</span>
+   <li><a href="#process-periodic-sync-registrations">Process periodic sync registrations</a><span>, in §7.2</span>
+   <li><a href="#dom-periodicsyncmanager-register">register(tag)</a><span>, in §8.3</span>
+   <li><a href="#dom-periodicsyncmanager-register">register(tag, options)</a><span>, in §8.3</span>
+   <li><a href="#respond-to-permission-revocation">Respond to permission revocation</a><span>, in §7.3</span>
    <li>
     service worker registration
     <ul>
-     <li><a href="#dom-periodicsyncmanager-service-worker-registration">attribute for PeriodicSyncManager</a><span>, in §7.3</span>
-     <li><a href="#periodicsync-registration-service-worker-registration">dfn for periodicsync registration</a><span>, in §3.1</span>
+     <li><a href="#periodicsyncmanager-service-worker-registration">dfn for PeriodicSyncManager</a><span>, in §8.3</span>
+     <li><a href="#periodic-sync-registration-service-worker-registration">dfn for periodic sync registration</a><span>, in §4.1</span>
     </ul>
+   <li><a href="#periodic-sync-registration-state">state</a><span>, in §4.1</span>
    <li>
     tag
     <ul>
-     <li><a href="#dom-periodicsyncevent-tag">attribute for PeriodicSyncEvent</a><span>, in §7.4</span>
-     <li><a href="#periodicsync-registration-tag">dfn for periodicsync registration</a><span>, in §3.1</span>
-     <li><a href="#dom-periodicsynceventinit-tag">dict-member for PeriodicSyncEventInit</a><span>, in §7.4</span>
+     <li><a href="#dom-periodicsyncevent-tag">attribute for PeriodicSyncEvent</a><span>, in §8.4</span>
+     <li><a href="#periodicsyncevent-tag">dfn for PeriodicSyncEvent</a><span>, in §8.4</span>
+     <li><a href="#periodic-sync-registration-tag">dfn for periodic sync registration</a><span>, in §4.1</span>
+     <li><a href="#dom-periodicsynceventinit-tag">dict-member for PeriodicSyncEventInit</a><span>, in §8.4</span>
     </ul>
-   <li><a href="#time-the-last-periodicsync-event-was-fired">time the last periodicSync event was fired</a><span>, in §3.3</span>
-   <li><a href="#periodicsync-registration-time-to-fire">time to fire</a><span>, in §3.1</span>
-   <li><a href="#dom-periodicsyncmanager-unregister">unregister(tag)</a><span>, in §7.3</span>
+   <li><a href="#periodic-sync-scheduler-time-of-last-fire">time of last fire</a><span>, in §4.2</span>
+   <li><a href="#periodic-sync-registration-time-to-fire">time to fire</a><span>, in §4.1</span>
+   <li><a href="#dom-periodicsyncmanager-unregister">unregister(tag)</a><span>, in §8.3</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-backgroundfetchmanager">
    <a href="https://wicg.github.io/background-fetch/#backgroundfetchmanager">https://wicg.github.io/background-fetch/#backgroundfetchmanager</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-backgroundfetchmanager">5. Resource Usage</a>
+    <li><a href="#ref-for-backgroundfetchmanager">6. Resource Usage</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-background-fetch">
    <a href="https://wicg.github.io/background-fetch/#background-fetch">https://wicg.github.io/background-fetch/#background-fetch</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-background-fetch">5. Resource Usage</a>
+    <li><a href="#ref-for-background-fetch">6. Resource Usage</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-context-object">
    <a href="https://dom.spec.whatwg.org/#context-object">https://dom.spec.whatwg.org/#context-object</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-context-object">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-context-object①">7.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-context-object②">(2)</a>
+    <li><a href="#ref-for-context-object">8.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-context-object①">(2)</a>
+    <li><a href="#ref-for-context-object②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-context-object③">(2)</a> <a href="#ref-for-context-object④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-eventhandler">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-eventhandler">7.1. Extensions to the ServiceWorkerGlobalScope interface</a>
+    <li><a href="#ref-for-eventhandler">8.1. Extensions to the ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
@@ -2086,72 +2159,76 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
   <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enqueue-the-following-steps">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-enqueue-the-following-steps①">(2)</a> <a href="#ref-for-enqueue-the-following-steps②">(3)</a>
-    <li><a href="#ref-for-enqueue-the-following-steps③">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-enqueue-the-following-steps④">(2)</a>
+    <li><a href="#ref-for-enqueue-the-following-steps">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-enqueue-the-following-steps①">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-enqueue-the-following-steps②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-enqueue-the-following-steps③">(2)</a> <a href="#ref-for-enqueue-the-following-steps④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-in-parallel">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-in-parallel">7.4.2. Fire a periodicSync event</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parallel-queue">3. Constructs</a>
+    <li><a href="#ref-for-in-parallel">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-in-parallel①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-starting-a-new-parallel-queue">3. Constructs</a>
+    <li><a href="#ref-for-starting-a-new-parallel-queue">3. Extensions to service worker registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-append">
    <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-append">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-list-append">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-assert">
    <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-assert">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-assert①">(2)</a>
+    <li><a href="#ref-for-assert">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-assert①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list">
    <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-list">8.3. PeriodicSyncManager interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-ordered-map">
+   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ordered-map">3. Extensions to service worker registration</a>
+    <li><a href="#ref-for-ordered-map①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-ordered-map②">(2)</a> <a href="#ref-for-ordered-map③">(3)</a> <a href="#ref-for-ordered-map④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
    <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-permissionstate-granted">4.1. Permission</a>
-    <li><a href="#ref-for-dom-permissionstate-granted①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dom-permissionstate-granted">5.1. Permission</a>
+    <li><a href="#ref-for-dom-permissionstate-granted①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dictdef-permissiondescriptor">
    <a href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor">https://w3c.github.io/permissions/#dictdef-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-permissiondescriptor">4.1. Permission</a>
-    <li><a href="#ref-for-dictdef-permissiondescriptor①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dictdef-permissiondescriptor">5.1. Permission</a>
+    <li><a href="#ref-for-dictdef-permissiondescriptor①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-enumdef-permissionstate">
    <a href="https://w3c.github.io/permissions/#enumdef-permissionstate">https://w3c.github.io/permissions/#enumdef-permissionstate</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-permissionstate">4.1. Permission</a>
-    <li><a href="#ref-for-enumdef-permissionstate①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-enumdef-permissionstate">5.1. Permission</a>
+    <li><a href="#ref-for-enumdef-permissionstate①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
    <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-permissiondescriptor-name">4.1. Permission</a>
-    <li><a href="#ref-for-dom-permissiondescriptor-name①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dom-permissiondescriptor-name">5.1. Permission</a>
+    <li><a href="#ref-for-dom-permissiondescriptor-name①">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-dom-permissiondescriptor-name②">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-secure-contexts">
@@ -2169,180 +2246,179 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
   <aside class="dfn-panel" data-for="term-for-extendableevent">
    <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent">7.4. The periodicSync event</a>
-    <li><a href="#ref-for-extendableevent①">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-extendableevent②">(2)</a>
+    <li><a href="#ref-for-extendableevent">8.4. The periodicsync event</a>
+    <li><a href="#ref-for-extendableevent①">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-extendableevent②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
    <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-extendableeventinit">7.4. The periodicSync event</a>
+    <li><a href="#ref-for-dictdef-extendableeventinit">8.4. The periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
    <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-serviceworkerglobalscope">7.1. Extensions to the ServiceWorkerGlobalScope interface</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope">8.1. Extensions to the ServiceWorkerGlobalScope interface</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
    <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-serviceworkerregistration">7.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a>
+    <li><a href="#ref-for-serviceworkerregistration">8.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
    <a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-active-worker">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-dfn-active-worker①">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-extendableevent-extend-lifetime-promises">
    <a href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises">https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-fire-functional-event">
    <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fire-functional-event">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-fire-functional-event">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type">
    <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">2. Concepts</a>
-    <li><a href="#ref-for-dfn-service-worker-client-frame-type①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dfn-service-worker-client-frame-type①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-service-worker-client-origin">
    <a href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin">https://w3c.github.io/ServiceWorker/#service-worker-client-origin</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-service-worker-client-origin">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-service-worker-client-origin①">4.2. Location Tracking</a> <a href="#ref-for-service-worker-client-origin②">(2)</a>
-    <li><a href="#ref-for-service-worker-client-origin③">5. Resource Usage</a>
-    <li><a href="#ref-for-service-worker-client-origin④">6.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-service-worker-client-origin⑤">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-service-worker-client-origin">2. Concepts</a>
+    <li><a href="#ref-for-service-worker-client-origin①">4.1. Periodic sync registration</a>
+    <li><a href="#ref-for-service-worker-client-origin②">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-service-worker-client-origin③">(2)</a> <a href="#ref-for-service-worker-client-origin④">(3)</a> <a href="#ref-for-service-worker-client-origin⑤">(4)</a>
+    <li><a href="#ref-for-service-worker-client-origin⑥">5.2. Location Tracking</a> <a href="#ref-for-service-worker-client-origin⑦">(2)</a>
+    <li><a href="#ref-for-service-worker-client-origin⑧">6. Resource Usage</a>
+    <li><a href="#ref-for-service-worker-client-origin⑨">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-service-worker-client-origin①⓪">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-service-worker-client-origin①①">7.3. Respond to permission revocation</a> <a href="#ref-for-service-worker-client-origin①②">(2)</a>
+    <li><a href="#ref-for-service-worker-client-origin①③">8.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-service-worker-client-origin①④">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
    <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1.1. Example</a>
-    <li><a href="#ref-for-dfn-service-worker①">2. Concepts</a>
-    <li><a href="#ref-for-dfn-service-worker②">7.4.2. Fire a periodicSync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client">
    <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2. Concepts</a>
-    <li><a href="#ref-for-dfn-service-worker-client①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dfn-service-worker-client①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration">
    <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-service-worker-registration">3. Constructs</a>
-    <li><a href="#ref-for-dfn-service-worker-registration①">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration②">7.2. Extensions to the ServiceWorkerRegistration interface</a>
-    <li><a href="#ref-for-dfn-service-worker-registration③">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-dfn-service-worker-registration④">(2)</a> <a href="#ref-for-dfn-service-worker-registration⑤">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-terminate-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#terminate-service-worker">https://w3c.github.io/ServiceWorker/#terminate-service-worker</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-terminate-service-worker">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-dfn-service-worker-registration">3. Extensions to service worker registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration①">4.1. Periodic sync registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration②">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-dfn-service-worker-registration③">8.2. Extensions to the ServiceWorkerRegistration interface</a>
+    <li><a href="#ref-for-dfn-service-worker-registration④">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-online">
    <a href="https://wicg.github.io/BackgroundSync/spec/#online">https://wicg.github.io/BackgroundSync/spec/#online</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-online">2. Concepts</a> <a href="#ref-for-online①">(2)</a>
-    <li><a href="#ref-for-online②">7.4.1. Firing periodicSync events</a>
+    <li><a href="#ref-for-online">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-online①">7.2. Process periodic sync registrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
    <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMString">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-idl-DOMString①">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-idl-DOMString②">(2)</a> <a href="#ref-for-idl-DOMString③">(3)</a>
-    <li><a href="#ref-for-idl-DOMString④">7.4. The periodicSync event</a> <a href="#ref-for-idl-DOMString⑤">(2)</a> <a href="#ref-for-idl-DOMString⑥">(3)</a>
+    <li><a href="#ref-for-idl-DOMString">3. Extensions to service worker registration</a>
+    <li><a href="#ref-for-idl-DOMString①">4.1. Periodic sync registration</a>
+    <li><a href="#ref-for-idl-DOMString②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a>
+    <li><a href="#ref-for-idl-DOMString⑤">8.4. The periodicsync event</a> <a href="#ref-for-idl-DOMString⑥">(2)</a> <a href="#ref-for-idl-DOMString⑦">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-EnforceRange">
    <a href="https://heycam.github.io/webidl/#EnforceRange">https://heycam.github.io/webidl/#EnforceRange</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-EnforceRange">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-EnforceRange">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
    <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Exposed">7.2. Extensions to the ServiceWorkerRegistration interface</a>
-    <li><a href="#ref-for-Exposed①">7.3. PeriodicSyncManager interface</a>
-    <li><a href="#ref-for-Exposed②">7.4. The periodicSync event</a>
+    <li><a href="#ref-for-Exposed">8.2. Extensions to the ServiceWorkerRegistration interface</a>
+    <li><a href="#ref-for-Exposed①">8.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-Exposed②">8.4. The periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
    <a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidaccesserror">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-invalidaccesserror">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidstateerror">
    <a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidstateerror">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-invalidstateerror①">(2)</a>
+    <li><a href="#ref-for-invalidstateerror">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-notallowederror">
    <a href="https://heycam.github.io/webidl/#notallowederror">https://heycam.github.io/webidl/#notallowederror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notallowederror">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-notallowederror">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-a-new-promise">
    <a href="https://heycam.github.io/webidl/#a-new-promise">https://heycam.github.io/webidl/#a-new-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-a-new-promise">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
+    <li><a href="#ref-for-a-new-promise">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-reject">
    <a href="https://heycam.github.io/webidl/#reject">https://heycam.github.io/webidl/#reject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reject">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a> <a href="#ref-for-reject③">(4)</a>
+    <li><a href="#ref-for-reject">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve">
    <a href="https://heycam.github.io/webidl/#resolve">https://heycam.github.io/webidl/#resolve</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resolve">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
+    <li><a href="#ref-for-resolve">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
    <a href="https://heycam.github.io/webidl/#idl-unsigned-long-long">https://heycam.github.io/webidl/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-unsigned-long-long">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-idl-unsigned-long-long">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
    <a href="https://heycam.github.io/webidl/#upon-fulfillment">https://heycam.github.io/webidl/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-upon-fulfillment">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-upon-fulfillment">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-upon-rejection">
    <a href="https://heycam.github.io/webidl/#upon-rejection">https://heycam.github.io/webidl/#upon-rejection</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-upon-rejection">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-upon-rejection">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-wait-for-all">
    <a href="https://heycam.github.io/webidl/#wait-for-all">https://heycam.github.io/webidl/#wait-for-all</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-wait-for-all">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-wait-for-all">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2365,7 +2441,6 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
      <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-enqueue-the-following-steps" style="color:initial">enqueue the following steps</span>
      <li><span class="dfn-paneled" id="term-for-in-parallel" style="color:initial">in parallel</span>
-     <li><span class="dfn-paneled" id="term-for-parallel-queue" style="color:initial">parallel queue</span>
      <li><span class="dfn-paneled" id="term-for-starting-a-new-parallel-queue" style="color:initial">starting a new parallel queue</span>
     </ul>
    <li>
@@ -2374,6 +2449,7 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
      <li><span class="dfn-paneled" id="term-for-list-append" style="color:initial">append</span>
      <li><span class="dfn-paneled" id="term-for-assert" style="color:initial">assert</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
+     <li><span class="dfn-paneled" id="term-for-ordered-map" style="color:initial">map</span>
     </ul>
    <li>
     <a data-link-type="biblio">[permissions]</a> defines the following terms:
@@ -2404,7 +2480,6 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
      <li><span class="dfn-paneled" id="term-for-dfn-service-worker" style="color:initial">service worker</span>
      <li><span class="dfn-paneled" id="term-for-dfn-service-worker-client" style="color:initial">service worker client</span>
      <li><span class="dfn-paneled" id="term-for-dfn-service-worker-registration" style="color:initial">service worker registration</span>
-     <li><span class="dfn-paneled" id="term-for-terminate-service-worker" style="color:initial">terminate service worker</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WEB-BACKGROUND-SYNC]</a> defines the following terms:
@@ -2460,14 +2535,14 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration" id="ref-for-serviceworkerregistration①①"><c- g>ServiceWorkerRegistration</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager①①"><c- n>PeriodicSyncManager</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="PeriodicSyncManager" href="#dom-serviceworkerregistration-periodicsync" id="ref-for-dom-serviceworkerregistration-periodicsync①"><c- g>periodicSync</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑧"><c- n>PeriodicSyncManager</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="PeriodicSyncManager" href="#dom-serviceworkerregistration-periodicsync" id="ref-for-dom-serviceworkerregistration-periodicsync①"><c- g>periodicSync</c-></a>;
 };
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a href="#periodicsyncmanager"><code><c- g>PeriodicSyncManager</c-></code></a> {
-    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-register" id="ref-for-dom-periodicsyncmanager-register①①"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a> <a href="#dom-periodicsyncmanager-register-tag-options-tag"><code><c- g>tag</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundsyncoptions" id="ref-for-dictdef-backgroundsyncoptions①"><c- n>BackgroundSyncOptions</c-></a> <a href="#dom-periodicsyncmanager-register-tag-options-options"><code><c- g>options</c-></code></a>);
-    <c- b>Promise</c->&lt;<c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-gettags" id="ref-for-dom-periodicsyncmanager-gettags①"><c- g>getTags</c-></a>();
-    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-unregister" id="ref-for-dom-periodicsyncmanager-unregister①"><c- g>unregister</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a> <a href="#dom-periodicsyncmanager-unregister-tag-tag"><code><c- g>tag</c-></code></a>);
+    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-register" id="ref-for-dom-periodicsyncmanager-register①"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a href="#dom-periodicsyncmanager-register-tag-options-tag"><code><c- g>tag</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-backgroundsyncoptions" id="ref-for-dictdef-backgroundsyncoptions①"><c- n>BackgroundSyncOptions</c-></a> <a href="#dom-periodicsyncmanager-register-tag-options-options"><code><c- g>options</c-></code></a>);
+    <c- b>Promise</c->&lt;<c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-gettags" id="ref-for-dom-periodicsyncmanager-gettags①"><c- g>getTags</c-></a>();
+    <c- b>Promise</c->&lt;<c- b>void</c->> <a class="idl-code" data-link-type="method" href="#dom-periodicsyncmanager-unregister" id="ref-for-dom-periodicsyncmanager-unregister①"><c- g>unregister</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><c- b>DOMString</c-></a> <a href="#dom-periodicsyncmanager-unregister-tag-tag"><code><c- g>tag</c-></code></a>);
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-backgroundsyncoptions"><code><c- g>BackgroundSyncOptions</c-></code></a> {
@@ -2475,236 +2550,211 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-periodicsynceventinit"><code><c- g>PeriodicSyncEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit①"><c- n>ExtendableEventInit</c-></a> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><c- b>DOMString</c-></a> <a data-type="DOMString " href="#dom-periodicsynceventinit-tag"><code><c- g>tag</c-></code></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><c- b>DOMString</c-></a> <a data-type="DOMString " href="#dom-periodicsynceventinit-tag"><code><c- g>tag</c-></code></a>;
 };
 
 [
-    <a href="#dom-periodicsyncevent-periodicsyncevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><c- b>DOMString</c-></a> <a href="#dom-periodicsyncevent-periodicsyncevent-type-init-type"><code><c- g>type</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-periodicsynceventinit" id="ref-for-dictdef-periodicsynceventinit①"><c- n>PeriodicSyncEventInit</c-></a> <a href="#dom-periodicsyncevent-periodicsyncevent-type-init-init"><code><c- g>init</c-></code></a>),
+    <a href="#dom-periodicsyncevent-periodicsyncevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><c- b>DOMString</c-></a> <a href="#dom-periodicsyncevent-periodicsyncevent-type-init-type"><code><c- g>type</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-periodicsynceventinit" id="ref-for-dictdef-periodicsynceventinit①"><c- n>PeriodicSyncEventInit</c-></a> <a href="#dom-periodicsyncevent-periodicsyncevent-type-init-init"><code><c- g>init</c-></code></a>),
     <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->
 ] <c- b>interface</c-> <a href="#periodicsyncevent"><code><c- g>PeriodicSyncEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent③"><c- n>ExtendableEvent</c-></a> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><c- b>DOMString</c-></a> <a data-readonly data-type="DOMString" href="#dom-periodicsyncevent-tag"><code><c- g>tag</c-></code></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-periodicsyncevent-tag" id="ref-for-dom-periodicsyncevent-tag①"><c- g>tag</c-></a>;
   };
 
 </pre>
-  <aside class="dfn-panel" data-for="in-the-background">
-   <b><a href="#in-the-background">#in-the-background</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodicsync-event-in-the-background">
+   <b><a href="#periodicsync-event-in-the-background">#periodicsync-event-in-the-background</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-in-the-background">4.2. Location Tracking</a>
-    <li><a href="#ref-for-in-the-background①">4.3. History Leaking</a>
+    <li><a href="#ref-for-periodicsync-event-in-the-background">5.2. Location Tracking</a>
+    <li><a href="#ref-for-periodicsync-event-in-the-background①">5.3. History Leaking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-background-sync-opportunity">
-   <b><a href="#periodic-background-sync-opportunity">#periodic-background-sync-opportunity</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="active-periodic-sync-registrations">
+   <b><a href="#active-periodic-sync-registrations">#active-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-background-sync-opportunity">1.1. Example</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-active-periodic-sync-registrations①">(2)</a> <a href="#ref-for-active-periodic-sync-registrations②">(3)</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations③">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations④">7.3. Respond to permission revocation</a> <a href="#ref-for-active-periodic-sync-registrations⑤">(2)</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations⑥">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-active-periodic-sync-registrations⑦">(2)</a> <a href="#ref-for-active-periodic-sync-registrations⑧">(3)</a> <a href="#ref-for-active-periodic-sync-registrations⑨">(4)</a> <a href="#ref-for-active-periodic-sync-registrations①⓪">(5)</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations①①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-processing-queue">
-   <b><a href="#periodicsync-processing-queue">#periodicsync-processing-queue</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-processing-queue">
+   <b><a href="#periodic-sync-processing-queue">#periodic-sync-processing-queue</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-processing-queue">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsync-processing-queue①">(2)</a> <a href="#ref-for-periodicsync-processing-queue②">(3)</a>
-    <li><a href="#ref-for-periodicsync-processing-queue③">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsync-processing-queue④">(2)</a>
+    <li><a href="#ref-for-periodic-sync-processing-queue">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-processing-queue①">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-periodic-sync-processing-queue②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-processing-queue③">(2)</a> <a href="#ref-for-periodic-sync-processing-queue④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-periodicsync-registrations">
-   <b><a href="#list-of-periodicsync-registrations">#list-of-periodicsync-registrations</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration">
+   <b><a href="#periodic-sync-registration">#periodic-sync-registration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-of-periodicsync-registrations">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-list-of-periodicsync-registrations①">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-list-of-periodicsync-registrations②">(2)</a> <a href="#ref-for-list-of-periodicsync-registrations③">(3)</a> <a href="#ref-for-list-of-periodicsync-registrations④">(4)</a> <a href="#ref-for-list-of-periodicsync-registrations⑤">(5)</a>
+    <li><a href="#ref-for-periodic-sync-registration">2. Concepts</a>
+    <li><a href="#ref-for-periodic-sync-registration①">3. Extensions to service worker registration</a>
+    <li><a href="#ref-for-periodic-sync-registration②">4.1. Periodic sync registration</a>
+    <li><a href="#ref-for-periodic-sync-registration③">4.3. Constants</a>
+    <li><a href="#ref-for-periodic-sync-registration④">5.1. Permission</a>
+    <li><a href="#ref-for-periodic-sync-registration⑤">5.3. History Leaking</a> <a href="#ref-for-periodic-sync-registration⑥">(2)</a>
+    <li><a href="#ref-for-periodic-sync-registration⑦">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-periodic-sync-registration⑧">7.2. Process periodic sync registrations</a> <a href="#ref-for-periodic-sync-registration⑨">(2)</a>
+    <li><a href="#ref-for-periodic-sync-registration①⓪">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-periodic-sync-registration①①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration①②">(2)</a> <a href="#ref-for-periodic-sync-registration①③">(3)</a>
+    <li><a href="#ref-for-periodic-sync-registration①④">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration">
-   <b><a href="#periodicsync-registration">#periodicsync-registration</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration-service-worker-registration">
+   <b><a href="#periodic-sync-registration-service-worker-registration">#periodic-sync-registration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration">2. Concepts</a>
-    <li><a href="#ref-for-periodicsync-registration①">3. Constructs</a>
-    <li><a href="#ref-for-periodicsync-registration②">3.1. PeriodicSync Registration</a> <a href="#ref-for-periodicsync-registration③">(2)</a> <a href="#ref-for-periodicsync-registration④">(3)</a>
-    <li><a href="#ref-for-periodicsync-registration⑤">3.3. Global State</a>
-    <li><a href="#ref-for-periodicsync-registration⑥">4.3. History Leaking</a> <a href="#ref-for-periodicsync-registration⑦">(2)</a>
-    <li><a href="#ref-for-periodicsync-registration⑧">6.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-periodicsync-registration⑨">6.2. Schedule processing</a>
-    <li><a href="#ref-for-periodicsync-registration①⓪">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsync-registration①①">(2)</a> <a href="#ref-for-periodicsync-registration①②">(3)</a>
-    <li><a href="#ref-for-periodicsync-registration①③">7.4. The periodicSync event</a>
-    <li><a href="#ref-for-periodicsync-registration①④">7.4.1. Firing periodicSync events</a>
-    <li><a href="#ref-for-periodicsync-registration①⑤">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsync-registration①⑥">(2)</a> <a href="#ref-for-periodicsync-registration①⑦">(3)</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration">2. Concepts</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration②">(2)</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration③">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration④">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑤">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑥">8.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑦">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-service-worker-registration">
-   <b><a href="#periodicsync-registration-service-worker-registration">#periodicsync-registration-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration-tag">
+   <b><a href="#periodic-sync-registration-tag">#periodic-sync-registration-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-service-worker-registration">6.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-periodicsync-registration-service-worker-registration①">7.3. PeriodicSyncManager interface</a>
-    <li><a href="#ref-for-periodicsync-registration-service-worker-registration②">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-periodic-sync-registration-tag">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-tag①">(2)</a> <a href="#ref-for-periodic-sync-registration-tag②">(3)</a> <a href="#ref-for-periodic-sync-registration-tag③">(4)</a>
+    <li><a href="#ref-for-periodic-sync-registration-tag④">8.4. The periodicsync event</a>
+    <li><a href="#ref-for-periodic-sync-registration-tag⑤">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-tag">
-   <b><a href="#periodicsync-registration-tag">#periodicsync-registration-tag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration-minimum-interval">
+   <b><a href="#periodic-sync-registration-minimum-interval">#periodic-sync-registration-minimum-interval</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-tag">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-periodicsync-registration-tag①">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsync-registration-tag②">(2)</a> <a href="#ref-for-periodicsync-registration-tag③">(3)</a> <a href="#ref-for-periodicsync-registration-tag④">(4)</a>
-    <li><a href="#ref-for-periodicsync-registration-tag⑤">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-periodic-sync-registration-minimum-interval">4.1. Periodic sync registration</a>
+    <li><a href="#ref-for-periodic-sync-registration-minimum-interval①">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-periodic-sync-registration-minimum-interval②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-minimum-interval③">(2)</a> <a href="#ref-for-periodic-sync-registration-minimum-interval④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-options">
-   <b><a href="#periodicsync-registration-options">#periodicsync-registration-options</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration-time-to-fire">
+   <b><a href="#periodic-sync-registration-time-to-fire">#periodic-sync-registration-time-to-fire</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-options">3.1. PeriodicSync Registration</a> <a href="#ref-for-periodicsync-registration-options①">(2)</a>
-    <li><a href="#ref-for-periodicsync-registration-options②">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsync-registration-options③">(2)</a> <a href="#ref-for-periodicsync-registration-options④">(3)</a>
+    <li><a href="#ref-for-periodic-sync-registration-time-to-fire">7.1. Calculate a time to fire</a> <a href="#ref-for-periodic-sync-registration-time-to-fire①">(2)</a> <a href="#ref-for-periodic-sync-registration-time-to-fire②">(3)</a> <a href="#ref-for-periodic-sync-registration-time-to-fire③">(4)</a>
+    <li><a href="#ref-for-periodic-sync-registration-time-to-fire④">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-registration-time-to-fire⑤">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="options-mininterval">
-   <b><a href="#options-mininterval">#options-mininterval</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration-state">
+   <b><a href="#periodic-sync-registration-state">#periodic-sync-registration-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-options-mininterval">3.1. PeriodicSync Registration</a> <a href="#ref-for-options-mininterval①">(2)</a>
-    <li><a href="#ref-for-options-mininterval②">6.1. Calculate a time to fire</a> <a href="#ref-for-options-mininterval③">(2)</a>
+    <li><a href="#ref-for-periodic-sync-registration-state">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-registration-state①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-state②">(2)</a> <a href="#ref-for-periodic-sync-registration-state③">(3)</a>
+    <li><a href="#ref-for-periodic-sync-registration-state④">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-state⑤">(2)</a> <a href="#ref-for-periodic-sync-registration-state⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-time-to-fire">
-   <b><a href="#periodicsync-registration-time-to-fire">#periodicsync-registration-time-to-fire</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-scheduler">
+   <b><a href="#periodic-sync-scheduler">#periodic-sync-scheduler</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-time-to-fire">6.1. Calculate a time to fire</a> <a href="#ref-for-periodicsync-registration-time-to-fire①">(2)</a> <a href="#ref-for-periodicsync-registration-time-to-fire②">(3)</a> <a href="#ref-for-periodicsync-registration-time-to-fire③">(4)</a>
-    <li><a href="#ref-for-periodicsync-registration-time-to-fire④">6.2. Schedule processing</a>
-    <li><a href="#ref-for-periodicsync-registration-time-to-fire⑤">7.4.1. Firing periodicSync events</a>
-    <li><a href="#ref-for-periodicsync-registration-time-to-fire⑥">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsync-registration-time-to-fire⑦">(2)</a>
+    <li><a href="#ref-for-periodic-sync-scheduler">4.2. Periodic Sync Scheduler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-count-of-retries">
-   <b><a href="#periodicsync-registration-count-of-retries">#periodicsync-registration-count-of-retries</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-scheduler-time-of-last-fire">
+   <b><a href="#periodic-sync-scheduler-time-of-last-fire">#periodic-sync-scheduler-time-of-last-fire</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-count-of-retries">6.1. Calculate a time to fire</a> <a href="#ref-for-periodicsync-registration-count-of-retries①">(2)</a> <a href="#ref-for-periodicsync-registration-count-of-retries②">(3)</a> <a href="#ref-for-periodicsync-registration-count-of-retries③">(4)</a> <a href="#ref-for-periodicsync-registration-count-of-retries④">(5)</a>
+    <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-registration-state">
-   <b><a href="#periodicsync-registration-registration-state">#periodicsync-registration-registration-state</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-scheduler-effective-minimum-interval">
+   <b><a href="#periodic-sync-scheduler-effective-minimum-interval">#periodic-sync-scheduler-effective-minimum-interval</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-registration-state">6.2. Schedule processing</a>
-    <li><a href="#ref-for-periodicsync-registration-registration-state①">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsync-registration-registration-state②">(2)</a> <a href="#ref-for-periodicsync-registration-registration-state③">(3)</a> <a href="#ref-for-periodicsync-registration-registration-state④">(4)</a>
-    <li><a href="#ref-for-periodicsync-registration-registration-state⑤">7.4.1. Firing periodicSync events</a>
-    <li><a href="#ref-for-periodicsync-registration-registration-state⑥">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsync-registration-registration-state⑦">(2)</a>
+    <li><a href="#ref-for-periodic-sync-scheduler-effective-minimum-interval">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-periodic-sync-scheduler-effective-minimum-interval①">7.2. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-pending">
-   <b><a href="#periodicsync-registration-pending">#periodicsync-registration-pending</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-for-any-origin">
+   <b><a href="#minimum-periodic-sync-interval-for-any-origin">#minimum-periodic-sync-interval-for-any-origin</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-pending">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-periodicsync-registration-pending①">6.2. Schedule processing</a>
-    <li><a href="#ref-for-periodicsync-registration-pending②">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsync-registration-pending③">(2)</a>
-    <li><a href="#ref-for-periodicsync-registration-pending④">7.4.1. Firing periodicSync events</a>
-    <li><a href="#ref-for-periodicsync-registration-pending⑤">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsync-registration-pending⑥">(2)</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin①">(2)</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin②">(3)</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin③">7.1. Calculate a time to fire</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-firing">
-   <b><a href="#periodicsync-registration-firing">#periodicsync-registration-firing</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-across-origins">
+   <b><a href="#minimum-periodic-sync-interval-across-origins">#minimum-periodic-sync-interval-across-origins</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsync-registration-firing">7.3. PeriodicSyncManager interface</a>
-    <li><a href="#ref-for-periodicsync-registration-firing①">7.4. The periodicSync event</a>
-    <li><a href="#ref-for-periodicsync-registration-firing②">7.4.2. Fire a periodicSync event</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="periodicsync-registration-reregisteredwhilefiring">
-   <b><a href="#periodicsync-registration-reregisteredwhilefiring">#periodicsync-registration-reregisteredwhilefiring</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-periodicsync-registration-reregisteredwhilefiring">7.3. PeriodicSyncManager interface</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="minimum-interval-for-any-origin">
-   <b><a href="#minimum-interval-for-any-origin">#minimum-interval-for-any-origin</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-minimum-interval-for-any-origin">3.2. Constants</a>
-    <li><a href="#ref-for-minimum-interval-for-any-origin①">6.1. Calculate a time to fire</a> <a href="#ref-for-minimum-interval-for-any-origin②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="minimum-interval-across-origins">
-   <b><a href="#minimum-interval-across-origins">#minimum-interval-across-origins</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-minimum-interval-across-origins">6.1. Calculate a time to fire</a> <a href="#ref-for-minimum-interval-across-origins①">(2)</a> <a href="#ref-for-minimum-interval-across-origins②">(3)</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-across-origins①">(2)</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins②">7.2. Process periodic sync registrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="maximum-number-of-retries">
    <b><a href="#maximum-number-of-retries">#maximum-number-of-retries</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-maximum-number-of-retries">3.2. Constants</a>
-    <li><a href="#ref-for-maximum-number-of-retries①">6.1. Calculate a time to fire</a> <a href="#ref-for-maximum-number-of-retries②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="time-the-last-periodicsync-event-was-fired">
-   <b><a href="#time-the-last-periodicsync-event-was-fired">#time-the-last-periodicsync-event-was-fired</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-time-the-last-periodicsync-event-was-fired">6.1. Calculate a time to fire</a> <a href="#ref-for-time-the-last-periodicsync-event-was-fired①">(2)</a>
+    <li><a href="#ref-for-maximum-number-of-retries">4.3. Constants</a>
+    <li><a href="#ref-for-maximum-number-of-retries①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="calculate-a-time-to-fire">
    <b><a href="#calculate-a-time-to-fire">#calculate-a-time-to-fire</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-calculate-a-time-to-fire">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-calculate-a-time-to-fire①">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-calculate-a-time-to-fire②">(2)</a>
-    <li><a href="#ref-for-calculate-a-time-to-fire③">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-calculate-a-time-to-fire">4.1. Periodic sync registration</a>
+    <li><a href="#ref-for-calculate-a-time-to-fire①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-calculate-a-time-to-fire②">(2)</a>
+    <li><a href="#ref-for-calculate-a-time-to-fire③">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculate-the-time-to-fire-of-the-first-attempt-of">
-   <b><a href="#calculate-the-time-to-fire-of-the-first-attempt-of">#calculate-the-time-to-fire-of-the-first-attempt-of</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="process-periodic-sync-registrations">
+   <b><a href="#process-periodic-sync-registrations">#process-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-calculate-the-time-to-fire-of-the-first-attempt-of">6.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-process-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="schedule-processing">
-   <b><a href="#schedule-processing">#schedule-processing</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="respond-to-permission-revocation">
+   <b><a href="#respond-to-permission-revocation">#respond-to-permission-revocation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-schedule-processing">6.2. Schedule processing</a>
-    <li><a href="#ref-for-schedule-processing①">7.3. PeriodicSyncManager interface</a>
-    <li><a href="#ref-for-schedule-processing②">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-respond-to-permission-revocation">7.3. Respond to permission revocation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkerregistration-periodic-sync-manager">
    <b><a href="#serviceworkerregistration-periodic-sync-manager">#serviceworkerregistration-periodic-sync-manager</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-serviceworkerregistration-periodic-sync-manager">7.2. Extensions to the ServiceWorkerRegistration interface</a>
+    <li><a href="#ref-for-serviceworkerregistration-periodic-sync-manager">8.2. Extensions to the ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-periodicsync">
    <b><a href="#dom-serviceworkerregistration-periodicsync">#dom-serviceworkerregistration-periodicsync</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-serviceworkerregistration-periodicsync">7.2. Extensions to the ServiceWorkerRegistration interface</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-periodicsync">8.2. Extensions to the ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodicsyncmanager">
    <b><a href="#periodicsyncmanager">#periodicsyncmanager</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsyncmanager">3.1. PeriodicSync Registration</a>
-    <li><a href="#ref-for-periodicsyncmanager①">7.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-periodicsyncmanager②">(2)</a> <a href="#ref-for-periodicsyncmanager③">(3)</a>
-    <li><a href="#ref-for-periodicsyncmanager④">7.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager⑤">(2)</a> <a href="#ref-for-periodicsyncmanager⑥">(3)</a> <a href="#ref-for-periodicsyncmanager⑦">(4)</a> <a href="#ref-for-periodicsyncmanager⑧">(5)</a>
+    <li><a href="#ref-for-periodicsyncmanager">8.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-periodicsyncmanager①">(2)</a> <a href="#ref-for-periodicsyncmanager②">(3)</a>
+    <li><a href="#ref-for-periodicsyncmanager③">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager④">(2)</a> <a href="#ref-for-periodicsyncmanager⑤">(3)</a> <a href="#ref-for-periodicsyncmanager⑥">(4)</a> <a href="#ref-for-periodicsyncmanager⑦">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-backgroundsyncoptions">
    <b><a href="#dictdef-backgroundsyncoptions">#dictdef-backgroundsyncoptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-backgroundsyncoptions">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dictdef-backgroundsyncoptions">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-service-worker-registration">
-   <b><a href="#dom-periodicsyncmanager-service-worker-registration">#dom-periodicsyncmanager-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodicsyncmanager-service-worker-registration">
+   <b><a href="#periodicsyncmanager-service-worker-registration">#periodicsyncmanager-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-periodicsyncmanager-service-worker-registration">7.2. Extensions to the ServiceWorkerRegistration interface</a>
-    <li><a href="#ref-for-dom-periodicsyncmanager-service-worker-registration①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-periodicsyncmanager-service-worker-registration">8.2. Extensions to the ServiceWorkerRegistration interface</a>
+    <li><a href="#ref-for-periodicsyncmanager-service-worker-registration①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager-service-worker-registration②">(2)</a> <a href="#ref-for-periodicsyncmanager-service-worker-registration③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-periodicsyncmanager-register">
    <b><a href="#dom-periodicsyncmanager-register">#dom-periodicsyncmanager-register</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-periodicsyncmanager-register">2. Concepts</a>
-    <li><a href="#ref-for-dom-periodicsyncmanager-register①">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dom-periodicsyncmanager-register">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-periodicsyncmanager-gettags">
    <b><a href="#dom-periodicsyncmanager-gettags">#dom-periodicsyncmanager-gettags</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-periodicsyncmanager-gettags">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dom-periodicsyncmanager-gettags">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-periodicsyncmanager-unregister">
    <b><a href="#dom-periodicsyncmanager-unregister">#dom-periodicsyncmanager-unregister</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-periodicsyncmanager-unregister">7.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-dom-periodicsyncmanager-unregister">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodicsync-event">
@@ -2712,49 +2762,133 @@ If a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync
    <ul>
     <li><a href="#ref-for-periodicsync-event">1.1. Example</a>
     <li><a href="#ref-for-periodicsync-event①">2. Concepts</a>
-    <li><a href="#ref-for-periodicsync-event②">3.1. PeriodicSync Registration</a> <a href="#ref-for-periodicsync-event③">(2)</a> <a href="#ref-for-periodicsync-event④">(3)</a>
-    <li><a href="#ref-for-periodicsync-event⑤">3.2. Constants</a> <a href="#ref-for-periodicsync-event⑥">(2)</a> <a href="#ref-for-periodicsync-event⑦">(3)</a>
-    <li><a href="#ref-for-periodicsync-event⑧">3.3. Global State</a> <a href="#ref-for-periodicsync-event⑨">(2)</a>
-    <li><a href="#ref-for-periodicsync-event①⓪">4.2. Location Tracking</a> <a href="#ref-for-periodicsync-event①①">(2)</a> <a href="#ref-for-periodicsync-event①②">(3)</a>
-    <li><a href="#ref-for-periodicsync-event①③">4.3. History Leaking</a> <a href="#ref-for-periodicsync-event①④">(2)</a> <a href="#ref-for-periodicsync-event①⑤">(3)</a> <a href="#ref-for-periodicsync-event①⑥">(4)</a>
-    <li><a href="#ref-for-periodicsync-event①⑦">5. Resource Usage</a> <a href="#ref-for-periodicsync-event①⑧">(2)</a>
-    <li><a href="#ref-for-periodicsync-event①⑨">6.1. Calculate a time to fire</a> <a href="#ref-for-periodicsync-event②⓪">(2)</a> <a href="#ref-for-periodicsync-event②①">(3)</a> <a href="#ref-for-periodicsync-event②②">(4)</a>
-    <li><a href="#ref-for-periodicsync-event②③">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsync-event②④">(2)</a> <a href="#ref-for-periodicsync-event②⑤">(3)</a>
+    <li><a href="#ref-for-periodicsync-event②">4.1. Periodic sync registration</a> <a href="#ref-for-periodicsync-event③">(2)</a>
+    <li><a href="#ref-for-periodicsync-event④">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-periodicsync-event⑤">(2)</a>
+    <li><a href="#ref-for-periodicsync-event⑥">4.3. Constants</a> <a href="#ref-for-periodicsync-event⑦">(2)</a> <a href="#ref-for-periodicsync-event⑧">(3)</a> <a href="#ref-for-periodicsync-event⑨">(4)</a>
+    <li><a href="#ref-for-periodicsync-event①⓪">5.1. Permission</a>
+    <li><a href="#ref-for-periodicsync-event①①">5.2. Location Tracking</a> <a href="#ref-for-periodicsync-event①②">(2)</a> <a href="#ref-for-periodicsync-event①③">(3)</a>
+    <li><a href="#ref-for-periodicsync-event①④">5.3. History Leaking</a> <a href="#ref-for-periodicsync-event①⑤">(2)</a> <a href="#ref-for-periodicsync-event①⑥">(3)</a> <a href="#ref-for-periodicsync-event①⑦">(4)</a>
+    <li><a href="#ref-for-periodicsync-event①⑧">6. Resource Usage</a> <a href="#ref-for-periodicsync-event①⑨">(2)</a>
+    <li><a href="#ref-for-periodicsync-event②⓪">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-periodicsync-event②①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-periodicsynceventinit">
    <b><a href="#dictdef-periodicsynceventinit">#dictdef-periodicsynceventinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-periodicsynceventinit">7.4. The periodicSync event</a>
+    <li><a href="#ref-for-dictdef-periodicsynceventinit">8.4. The periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodicsyncevent">
    <b><a href="#periodicsyncevent">#periodicsyncevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodicsyncevent">7.4. The periodicSync event</a>
-    <li><a href="#ref-for-periodicsyncevent①">7.4.2. Fire a periodicSync event</a> <a href="#ref-for-periodicsyncevent②">(2)</a> <a href="#ref-for-periodicsyncevent③">(3)</a>
+    <li><a href="#ref-for-periodicsyncevent">8.4. The periodicsync event</a>
+    <li><a href="#ref-for-periodicsyncevent①">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodicsyncevent②">(2)</a> <a href="#ref-for-periodicsyncevent③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="periodicsyncevent-tag">
+   <b><a href="#periodicsyncevent-tag">#periodicsyncevent-tag</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-periodicsyncevent-tag">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-periodicsyncevent-tag">
    <b><a href="#dom-periodicsyncevent-tag">#dom-periodicsyncevent-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-periodicsyncevent-tag">7.4.2. Fire a periodicSync event</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="retry">
-   <b><a href="#retry">#retry</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-retry">6.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-dom-periodicsyncevent-tag">8.4. The periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fire-a-periodicsync-event">
    <b><a href="#fire-a-periodicsync-event">#fire-a-periodicsync-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fire-a-periodicsync-event">6.2. Schedule processing</a>
-    <li><a href="#ref-for-fire-a-periodicsync-event①">7.4.1. Firing periodicSync events</a>
-    <li><a href="#ref-for-fire-a-periodicsync-event②">7.4.2. Fire a periodicSync event</a>
+    <li><a href="#ref-for-fire-a-periodicsync-event">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-fire-a-periodicsync-event①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
+<script>/* script-var-click-highlighting */
+
+    document.addEventListener("click", e=>{
+        if(e.target.nodeName == "VAR") {
+            highlightSameAlgoVars(e.target);
+        }
+    });
+    {
+        const indexCounts = new Map();
+        const indexNames = new Map();
+        function highlightSameAlgoVars(v) {
+            // Find the algorithm container.
+            let algoContainer = null;
+            let searchEl = v;
+            while(algoContainer == null && searchEl != document.body) {
+                searchEl = searchEl.parentNode;
+                if(searchEl.hasAttribute("data-algorithm")) {
+                    algoContainer = searchEl;
+                }
+            }
+
+            // Not highlighting document-global vars,
+            // too likely to be unrelated.
+            if(algoContainer == null) return;
+
+            const algoName = algoContainer.getAttribute("data-algorithm");
+            const varName = getVarName(v);
+            const addClass = !v.classList.contains("selected");
+            let highlightClass = null;
+            if(addClass) {
+                const index = chooseHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] += 1;
+                indexNames.set(algoName+"///"+varName, index);
+                highlightClass = nameFromIndex(index);
+            } else {
+                const index = previousHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] -= 1;
+                highlightClass = nameFromIndex(index);
+            }
+
+            // Find all same-name vars, and toggle their class appropriately.
+            for(const el of algoContainer.querySelectorAll("var")) {
+                if(getVarName(el) == varName) {
+                    el.classList.toggle("selected", addClass);
+                    el.classList.toggle(highlightClass, addClass);
+                }
+            }
+        }
+        function getVarName(el) {
+            return el.textContent.replace(/(\s| )+/, " ").trim();
+        }
+        function chooseHighlightIndex(algoName, varName) {
+            let indexes = null;
+            if(indexCounts.has(algoName)) {
+                indexes = indexCounts.get(algoName);
+            } else {
+                // 7 classes right now
+                indexes = [0,0,0,0,0,0,0];
+                indexCounts.set(algoName, indexes);
+            }
+
+            // If the element was recently unclicked,
+            // *and* that color is still unclaimed,
+            // give it back the same color.
+            const lastIndex = previousHighlightIndex(algoName, varName);
+            if(indexes[lastIndex] === 0) return lastIndex;
+
+            // Find the earliest index with the lowest count.
+            const minCount = Math.min.apply(null, indexes);
+            let index = null;
+            for(var i = 0; i < indexes.length; i++) {
+                if(indexes[i] == minCount) {
+                    return i;
+                }
+            }
+        }
+        function previousHighlightIndex(algoName, varName) {
+            return indexNames.get(algoName+"///"+varName);
+        }
+        function nameFromIndex(index) {
+            return "selected" + index;
+        }
+    }
+    </script>
 <script>/* script-dfn-panel */
 
 document.body.addEventListener("click", function(e) {

--- a/spec/PeriodicBackgroundSync-index.html
+++ b/spec/PeriodicBackgroundSync-index.html
@@ -1215,7 +1215,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version e1a165f1c2fb1cc2aceb87e110984a42830c36fa" name="generator">
   <link href="https://wicg.github.io/BackgroundSync/spec/PeriodicBackgroundSync-index.html" rel="canonical">
-  <meta content="cfe60125fe5e7a911100466afc0f8e1bfddd3af2" name="document-revision">
+  <meta content="88d4f39f5a7b3c4e5a2524926b6a3aa80dc270b5" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1609,7 +1609,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <p class="note" role="note"><span>Note:</span> Periodic Background Sync doesn’t share namespace with Background Sync, so an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①">origin</a> can have registrations of both types with the same tag.</p>
     <p><dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-minimum-interval">minimum interval</dfn> (a long long), which is used to specify the minimum interval, in milliseconds, at which the periodic synchronization should happen. <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval">minimum interval</a> is a suggestion to the user agent.</p>
     <p class="note" role="note"><span>Note:</span> The actual interval at which <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②">periodicsync events</a> are fired MUST be greater than or equal to this.</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-anchor-time">anchor time</dfn> (a timestamp), the previous time a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event③">periodicsync event</a> fired for this <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration②">periodic sync registration</a>, or the time of initial registration.</p>
+    <p>An <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-anchor-time">anchor time</dfn> (a timestamp), the previous time a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event③">periodicsync event</a> fired for this <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration②">periodic sync registration</a>, or the time of initial registration.</p>
     <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-state">state</dfn>, which is one of "<code>pending</code>", "<code>firing</code>", "<code>suspended</code>" or "<code>reregistered-while-firing</code>". It is initially set to "<code>pending</code>".</p>
    </div>
    <h3 class="heading settled" data-level="4.2" id="periodic-sync-scheduler-construct"><span class="secno">4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler">Periodic Sync Scheduler</dfn></span><a class="self-link" href="#periodic-sync-scheduler-construct"></a></h3>

--- a/spec/PeriodicBackgroundSync-index.html
+++ b/spec/PeriodicBackgroundSync-index.html
@@ -1213,9 +1213,9 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 60a9f27730c0c9ae3e20485f824cef3713caf5fb" name="generator">
+  <meta content="Bikeshed version e1a165f1c2fb1cc2aceb87e110984a42830c36fa" name="generator">
   <link href="https://wicg.github.io/BackgroundSync/spec/PeriodicBackgroundSync-index.html" rel="canonical">
-  <meta content="e9588bb4066a6031fc92354497a365c03913653b" name="document-revision">
+  <meta content="cfe60125fe5e7a911100466afc0f8e1bfddd3af2" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1534,9 +1534,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li>
      <a href="#algorithms"><span class="secno">7</span> <span class="content">Algorithms</span></a>
      <ol class="toc">
-      <li><a href="#caculate-time-to-fire"><span class="secno">7.1</span> <span class="content"><span>Calculate a time to fire</span></span></a>
-      <li><a href="#process-periodic-sync-registrations-algorithm"><span class="secno">7.2</span> <span class="content"><span>Process periodic sync registrations</span></span></a>
-      <li><a href="#responding-to-permission-revocation-algorithm"><span class="secno">7.3</span> <span class="content"><span>Respond to permission revocation</span></span></a>
+      <li><a href="#process-periodic-sync-registrations-algorithm"><span class="secno">7.1</span> <span class="content"><span>Process periodic sync registrations</span></span></a>
+      <li><a href="#responding-to-permission-revocation-algorithm"><span class="secno">7.2</span> <span class="content"><span>Respond to permission revocation</span></span></a>
      </ol>
     <li>
      <a href="#api-description"><span class="secno">8</span> <span class="content">API Description</span></a>
@@ -1610,7 +1609,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <p class="note" role="note"><span>Note:</span> Periodic Background Sync doesn’t share namespace with Background Sync, so an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①">origin</a> can have registrations of both types with the same tag.</p>
     <p><dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-minimum-interval">minimum interval</dfn> (a long long), which is used to specify the minimum interval, in milliseconds, at which the periodic synchronization should happen. <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval">minimum interval</a> is a suggestion to the user agent.</p>
     <p class="note" role="note"><span>Note:</span> The actual interval at which <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②">periodicsync events</a> are fired MUST be greater than or equal to this.</p>
-    <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-time-to-fire">time to fire</dfn> (a timestamp), which is the soonest time <a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire"> calculated</a> by the user agent at which it is appropriate to fire the next <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event③">periodicsync event</a> for the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration②">periodic sync registration</a>.</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-anchor-time">anchor time</dfn> (a timestamp), the previous time a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event③">periodicsync event</a> fired for this <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration②">periodic sync registration</a>, or the time of initial registration.</p>
     <p>A <dfn class="dfn-paneled" data-dfn-for="periodic sync registration" data-dfn-type="dfn" data-noexport id="periodic-sync-registration-state">state</dfn>, which is one of "<code>pending</code>", "<code>firing</code>", "<code>suspended</code>" or "<code>reregistered-while-firing</code>". It is initially set to "<code>pending</code>".</p>
    </div>
    <h3 class="heading settled" data-level="4.2" id="periodic-sync-scheduler-construct"><span class="secno">4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler">Periodic Sync Scheduler</dfn></span><a class="self-link" href="#periodic-sync-scheduler-construct"></a></h3>
@@ -1621,12 +1620,12 @@ In response to these triggers, the scheduler either schedules delayed processing
     <ul>
      <li data-md>
       <p>The <dfn class="dfn-paneled" data-dfn-for="periodic sync scheduler" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler-time-of-last-fire">time of last fire</dfn>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">map</a>, where each key is an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin②">origin</a>, and each item is a timestamp. The keys of this map are the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin③">origins</a> associated with the <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration①">service worker registrations</a> of <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations">active periodic sync registrations</a>. This is initially an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">map</a>.</p>
-     <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="periodic sync scheduler" data-dfn-type="dfn" data-noexport id="periodic-sync-scheduler-effective-minimum-interval">Effective minimum interval</dfn>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">map</a>, where each key is an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin④">origin</a>, and each item is a long long, representing a time interval. The keys of this map are the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑤">origins</a> associated with the <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration②">service worker registrations</a> of <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①">active periodic sync registrations</a>. This is initially an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">map</a>.</p>
     </ul>
    </div>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="effective-minimum-sync-interval-for-origin">effective minimum sync interval for origin</dfn> <var>origin</var> (an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin④">origin</a>), is the <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin">minimum periodic sync interval for any origin</a> + some user agent defined amount for the <var>origin</var>.</p>
+   <p class="note" role="note"><span>Note:</span> The user agent defined amount could be based off the amount of engagement the user has with the origin. This value can be different each time <a data-link-type="dfn" href="#effective-minimum-sync-interval-for-origin" id="ref-for-effective-minimum-sync-interval-for-origin">effective minimum sync interval for origin</a> is called.</p>
    <p>The scheduler <a data-link-type="dfn" href="#process-periodic-sync-registrations" id="ref-for-process-periodic-sync-registrations">processes periodic sync registrations</a>.</p>
-   <p class="note" role="note"><span>Note:</span> Browsers may suspend this processing loop when there are no <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations②">active periodic sync registrations</a> to conserve resources.</p>
+   <p class="note" role="note"><span>Note:</span> Browsers may suspend this processing loop when there are no <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①">active periodic sync registrations</a> to conserve resources.</p>
    <h3 class="heading settled" data-level="4.3" id="constants"><span class="secno">4.3. </span><span class="content">Constants</span><a class="self-link" href="#constants"></a></h3>
     As recommended in <a href="#privacy">§ 5 Privacy Considerations</a> and <a href="#resources">§ 6 Resource Usage</a>, the user agent SHOULD also define: 
    <ul>
@@ -1635,16 +1634,16 @@ In response to these triggers, the scheduler either schedules delayed processing
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="minimum-periodic-sync-interval-across-origins">minimum periodic sync interval across origins</dfn>, a long long, that represents the minimum gap between <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑦">periodicsync events</a> across all origins.</p>
    </ul>
-   <p><a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins">minimum periodic sync interval across origins</a> MUST be greater than or equal to <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin">minimum periodic sync interval for any origin</a>.
+   <p><a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins">minimum periodic sync interval across origins</a> MUST be greater than or equal to <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin①">minimum periodic sync interval for any origin</a>.
 If undefined, these are set to 43200000, which is twelve hours in milliseconds.</p>
-   <p class="note" role="note"><span>Note:</span> Two caps on frequency are needed because conforming to the cap enforced by <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin①">minimum periodic sync interval for any origin</a> for each origin can still cause the browser to fire <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑧">periodicsync events</a> very frequently. This can happen, for instance, when there are many <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration③">periodic sync registrations</a> for different origins. <a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins①">minimum periodic sync interval across origins</a> ensures there’s a global cap on how often these events are fired.</p>
-   <p>The user agent MAY define a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="maximum-number-of-retries">maximum number of retries</dfn>, a number, allowed for each <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑨">periodicsync event</a>. In choosing this, the user agent SHOULD ensure that the time needed to attempt the <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries">maximum number of retries</a> is an order of magnitude smaller than the <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin②">minimum periodic sync interval for any origin</a>. If undefined, this number is zero.</p>
+   <p class="note" role="note"><span>Note:</span> Two caps on frequency are needed because conforming to the cap enforced by <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin②">minimum periodic sync interval for any origin</a> for each origin can still cause the browser to fire <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑧">periodicsync events</a> very frequently. This can happen, for instance, when there are many <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration③">periodic sync registrations</a> for different origins. <a data-link-type="dfn" href="#minimum-periodic-sync-interval-across-origins" id="ref-for-minimum-periodic-sync-interval-across-origins①">minimum periodic sync interval across origins</a> ensures there’s a global cap on how often these events are fired.</p>
+   <p>The user agent MAY define a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="maximum-number-of-retries">maximum number of retries</dfn>, a number, allowed for each <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event⑨">periodicsync event</a>. In choosing this, the user agent SHOULD ensure that the time needed to attempt the <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries">maximum number of retries</a> is an order of magnitude smaller than the <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin③">minimum periodic sync interval for any origin</a>. If undefined, this number is zero.</p>
    <h2 class="heading settled" data-level="5" id="privacy"><span class="secno">5. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="permission"><span class="secno">5.1. </span><span class="content">Permission</span><a class="self-link" href="#permission"></a></h3>
     Periodic Background Sync is only available if the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#enumdef-permissionstate" id="ref-for-enumdef-permissionstate">PermissionState</a></code> for a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor">PermissionDescriptor</a></code> with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name">name</a></code> <code>"periodic-background-sync"</code> is <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissionstate-granted" id="ref-for-dom-permissionstate-granted">granted</a></code>. In addition, user agents SHOULD offer a way for the user to disable Periodic Background Sync.
-When Periodic Background Sync is disabled, <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⓪">periodicsync events</a> MUST NOT be dispatched for the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration④">periodic sync registrations</a> affected by this permission. (See <a href="#responding-to-permission-revocation-algorithm">§ 7.3 Respond to permission revocation</a>). 
+When Periodic Background Sync is disabled, <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⓪">periodicsync events</a> MUST NOT be dispatched for the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration④">periodic sync registrations</a> affected by this permission. (See <a href="#responding-to-permission-revocation-algorithm">§ 7.2 Respond to permission revocation</a>). 
    <h3 class="heading settled" data-level="5.2" id="location-tracking"><span class="secno">5.2. </span><span class="content">Location Tracking</span><a class="self-link" href="#location-tracking"></a></h3>
-    Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①①">periodicsync event</a> while <a data-link-type="dfn" href="#periodicsync-event-in-the-background" id="ref-for-periodicsync-event-in-the-background">in the background</a> may reveal the client’s IP address to the server after the user has left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①②">periodicsync event</a>s, to reduce the amount of time the user’s location can be tracked by the website. Further, the user agent SHOULD limit persistent location tracking by capping the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①③">periodicsync event</a>s, both for an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑥">origin</a>, and across <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑦">origins</a>. 
+    Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①①">periodicsync event</a> while <a data-link-type="dfn" href="#periodicsync-event-in-the-background" id="ref-for-periodicsync-event-in-the-background">in the background</a> may reveal the client’s IP address to the server after the user has left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①②">periodicsync event</a>s, to reduce the amount of time the user’s location can be tracked by the website. Further, the user agent SHOULD limit persistent location tracking by capping the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①③">periodicsync event</a>s, both for an <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑤">origin</a>, and across <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑥">origins</a>. 
    <h3 class="heading settled" data-level="5.3" id="history-leaking"><span class="secno">5.3. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
     Fetch requests within the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①④">periodicsync event</a> while <a data-link-type="dfn" href="#periodicsync-event-in-the-background" id="ref-for-periodicsync-event-in-the-background①">in the background</a> may reveal something about the client’s navigation history to middleboxes on networks different from the one used to create the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑤">periodic sync registration</a>. For instance, the client might visit site https://example.com, which registers a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑤">periodicsync event</a>, but based on the implementation, might not fire until after the user has navigated away from the page and changed networks. Middleboxes on the new network may see the fetch requests that the <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑥">periodicsync event</a> makes. The fetch requests are HTTPS so the request contents will not be leaked but the destination of the fetch request and domain may be (via DNS lookups and IP address of the request). To prevent this leakage of browsing history, the user agent MAY choose to only fire <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑦">periodicsync events</a> on the network the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑥">periodic sync registration</a> was made on, with the understanding that it will reduce usability by not allowing synchronization opportunistically. 
    <h2 class="heading settled" data-level="6" id="resources"><span class="secno">6. </span><span class="content">Resource Usage</span><a class="self-link" href="#resources"></a></h2>
@@ -1652,30 +1651,10 @@ When Periodic Background Sync is disabled, <a data-link-type="dfn" href="#period
    <p>A website will most likely download resources from the network when processing a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑧">periodicsync event</a>. The underlying operating system may launch the user agent to dispatch these events, and may keep it awake for a pre-defined duration to allow processing of the events. Both cause battery drain.
 The user agent should cap the duration and frequency of these events to limit resource usage by websites when the user has navigated away.</p>
    <p>Large resources should be downloaded by registering a <a data-link-type="dfn" href="https://wicg.github.io/background-fetch/#background-fetch" id="ref-for-background-fetch">background fetch</a> via the <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/background-fetch/#backgroundfetchmanager" id="ref-for-backgroundfetchmanager">BackgroundFetchManager</a></code> interface.</p>
-   <p>In addition, the user agent should consider other factors such as user engagement with the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑧">origin</a>, and any user indications to temporarily reduce data consumption, such as a Data Saving Mode, to adjust the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑨">periodicsync events</a>.</p>
+   <p>In addition, the user agent should consider other factors such as user engagement with the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑦">origin</a>, and any user indications to temporarily reduce data consumption, such as a Data Saving Mode, to adjust the frequency of <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event①⑨">periodicsync events</a>.</p>
    <h2 class="heading settled" data-level="7" id="algorithms"><span class="secno">7. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
-   <div class="algorithm" data-algorithm="Calculate a time to fire">
-    <h3 class="heading settled" data-level="7.1" id="caculate-time-to-fire"><span class="secno">7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="calculate-a-time-to-fire">Calculate a time to fire</dfn></span><a class="self-link" href="#caculate-time-to-fire"></a></h3>
-     This section describes how a user agent can calculate the <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire">time to fire</a> for a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑦">periodic sync registration</a>, <var>registration</var>. <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire①">time to fire</a> value MUST be updated in response to various triggers such as registration, unregistration, change in <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online">online</a> status, and completion of an attempt to fire a <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②⓪">periodicsync event</a>. 
-    <p>Calculating the <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire②">time to fire</a> for <var>registration</var> involves running these steps:</p>
-    <ol>
-     <li data-md>
-      <p>Let <var>now</var>, a timestamp, represent the current time.</p>
-     <li data-md>
-      <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑨">origin</a> associated with <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration③">service worker registration</a>.</p>
-     <li data-md>
-      <p>Let <var>effectiveMinimumIntervalForOrigin</var> be the greater of <a data-link-type="dfn" href="#minimum-periodic-sync-interval-for-any-origin" id="ref-for-minimum-periodic-sync-interval-for-any-origin③">minimum periodic sync interval for any origin</a> and <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval①">minimum interval</a>.</p>
-     <li data-md>
-      <p>Increment <var>effectiveMinimumIntervalForOrigin</var> by some user agent defined amount.</p>
-      <p class="note" role="note"><span>Note:</span> User agents can use this to delay synchronization due to the user’s engagement with <var>origin</var>.</p>
-     <li data-md>
-      <p>Set <a data-link-type="dfn" href="#periodic-sync-scheduler-effective-minimum-interval" id="ref-for-periodic-sync-scheduler-effective-minimum-interval">effective minimum interval</a> for <var>origin</var> to <var>effectiveMinimumIntervalForOrigin</var>.</p>
-     <li data-md>
-      <p>Set <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire③">time to fire</a> to <var>now</var> + <var>effectiveMinimumIntervalForOrigin</var>.</p>
-    </ol>
-   </div>
    <div class="algorithm" data-algorithm="Process periodic sync registrations">
-    <h3 class="heading settled" data-level="7.2" id="process-periodic-sync-registrations-algorithm"><span class="secno">7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-periodic-sync-registrations">Process periodic sync registrations</dfn></span><a class="self-link" href="#process-periodic-sync-registrations-algorithm"></a></h3>
+    <h3 class="heading settled" data-level="7.1" id="process-periodic-sync-registrations-algorithm"><span class="secno">7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-periodic-sync-registrations">Process periodic sync registrations</dfn></span><a class="self-link" href="#process-periodic-sync-registrations-algorithm"></a></h3>
      When the user agent starts, run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
     <ol>
      <li data-md>
@@ -1690,23 +1669,23 @@ The user agent should cap the duration and frequency of these events to limit re
         <ol>
          <li data-md>
           <p>Wait for some user agent defined amount of time.</p>
-          <p class="note" role="note"><span>Note:</span> This can be used to group synchronization for different <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑧">periodic sync registrations</a> into a single device wake-up.</p>
+          <p class="note" role="note"><span>Note:</span> This can be used to group synchronization for different <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑦">periodic sync registrations</a> into a single device wake-up.</p>
          <li data-md>
-          <p>Wait until <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online①">online</a>.</p>
+          <p>Wait until <a data-link-type="dfn" href="https://wicg.github.io/BackgroundSync/spec/#online" id="ref-for-online">online</a>.</p>
          <li data-md>
-          <p>For each <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration②">service worker registration</a> <var>registration</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps">enqueue the following steps</a> to its <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue">periodic sync processing queue</a>:</p>
+          <p>For each <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration②">service worker registration</a> <var>registration</var> that is not <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered" id="ref-for-dfn-service-worker-registration-unregistered">unregistered</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps">enqueue the following steps</a> to <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue">periodic sync processing queue</a>:</p>
           <ol>
            <li data-md>
-            <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①⓪">origin</a> associated with <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration④">service worker registration</a>.</p>
+            <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑧">origin</a> associated with <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration②">service worker registration</a>.</p>
            <li data-md>
-            <p>If <a data-link-type="dfn" href="#periodic-sync-scheduler-time-of-last-fire" id="ref-for-periodic-sync-scheduler-time-of-last-fire">time of last fire</a> for <var>origin</var> + <a data-link-type="dfn" href="#periodic-sync-scheduler-effective-minimum-interval" id="ref-for-periodic-sync-scheduler-effective-minimum-interval①">effective minimum interval</a> for <var>origin</var> is greater than now, continue.</p>
+            <p>If <a data-link-type="dfn" href="#periodic-sync-scheduler-time-of-last-fire" id="ref-for-periodic-sync-scheduler-time-of-last-fire">time of last fire</a>[<var>origin</var>] + the <a data-link-type="dfn" href="#effective-minimum-sync-interval-for-origin" id="ref-for-effective-minimum-sync-interval-for-origin①">effective minimum sync interval for origin</a> <var>origin</var> is greater than now, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
            <li data-md>
-            <p>For each <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑨">periodic sync registration</a> <var>periodicSyncRegistration</var> in <var>registration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations③">active periodic sync registrations</a>:</p>
+            <p>For each <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑧">periodic sync registration</a> <var>periodicSyncRegistration</var> in <var>registration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations②">active periodic sync registrations</a>:</p>
             <ol>
              <li data-md>
-              <p>If <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state">state</a> is not "<code>pending</code>", continue.</p>
+              <p>If <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state">state</a> is not "<code>pending</code>", <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
              <li data-md>
-              <p>If <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire④">time to fire</a> is in the future, continue.</p>
+              <p>If <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-anchor-time" id="ref-for-periodic-sync-registration-anchor-time">anchor time</a> + <var>periodicSyncRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval①">minimum interval</a> is greater than now, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
              <li data-md>
               <p>Set <var>firedPeriodicSync</var> to true.</p>
              <li data-md>
@@ -1718,14 +1697,14 @@ The user agent should cap the duration and frequency of these events to limit re
     </ol>
    </div>
    <div class="algorithm" data-algorithm="Respond to permission revocation">
-    <h3 class="heading settled" data-level="7.3" id="responding-to-permission-revocation-algorithm"><span class="secno">7.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="respond-to-permission-revocation">Respond to permission revocation</dfn></span><a class="self-link" href="#responding-to-permission-revocation-algorithm"></a></h3>
-     To <a data-link-type="dfn" href="#respond-to-permission-revocation" id="ref-for-respond-to-permission-revocation">respond to revocation</a> of the permission with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name①">name</a></code> <code>"periodic-background-sync"</code> for <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①①">origin</a> <var>origin</var>, the user agent MUST <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps①">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue①">periodic sync processing queue</a>: 
+    <h3 class="heading settled" data-level="7.2" id="responding-to-permission-revocation-algorithm"><span class="secno">7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="respond-to-permission-revocation">Respond to permission revocation</dfn></span><a class="self-link" href="#responding-to-permission-revocation-algorithm"></a></h3>
+     To <a data-link-type="dfn" href="#respond-to-permission-revocation" id="ref-for-respond-to-permission-revocation">respond to revocation</a> of the permission with <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name" id="ref-for-dom-permissiondescriptor-name①">name</a></code> <code>"periodic-background-sync"</code> for <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin⑨">origin</a> <var>origin</var>, the user agent MUST <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps" id="ref-for-enqueue-the-following-steps①">enqueue the following steps</a> to the <a data-link-type="dfn" href="#periodic-sync-processing-queue" id="ref-for-periodic-sync-processing-queue①">periodic sync processing queue</a>: 
     <ol>
      <li data-md>
-      <p>For each <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①⓪">periodic sync registration</a> <var>registration</var> in <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations④">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑤">service worker registration</a> is associated with the same <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①②">origin</a> as <var>origin</var>:</p>
+      <p>For each <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration⑨">periodic sync registration</a> <var>registration</var> in <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations③">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration③">service worker registration</a> is associated with the same <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①⓪">origin</a> as <var>origin</var>:</p>
       <ol>
        <li data-md>
-        <p>Remove <var>registration</var> from <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑤">active periodic sync registrations</a>.</p>
+        <p>Remove <var>registration</var> from <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations④">active periodic sync registrations</a>.</p>
       </ol>
     </ol>
    </div>
@@ -1754,7 +1733,7 @@ The user agent should cap the duration and frequency of these events to limit re
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-backgroundsyncoptions"><code><c- g>BackgroundSyncOptions</c-></code></dfn> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="idl-code" data-default="0" data-dfn-for="BackgroundSyncOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-backgroundsyncoptions-mininterval"><code><c- g>minInterval</c-></code><a class="self-link" href="#dom-backgroundsyncoptions-mininterval"></a></dfn> = 0;
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#EnforceRange" id="ref-for-EnforceRange"><c- g>EnforceRange</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long-long" id="ref-for-idl-unsigned-long-long"><c- b>unsigned</c-> <c- b>long</c-> <c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-default="0" data-dfn-for="BackgroundSyncOptions" data-dfn-type="dict-member" data-export data-type="unsigned long long " id="dom-backgroundsyncoptions-mininterval"><code><c- g>minInterval</c-></code></dfn> = 0;
 };
 </pre>
    <div> A <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager④">PeriodicSyncManager</a></code> has a <dfn class="dfn-paneled" data-dfn-for="PeriodicSyncManager" data-dfn-type="dfn" data-noexport id="periodicsyncmanager-service-worker-registration">service worker registration</dfn> (a <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration④">service worker registration</a>). </div>
@@ -1770,7 +1749,7 @@ The user agent should cap the duration and frequency of these events to limit re
      <li data-md>
       <p>Let <var>isBackground</var>, a boolean, be true.</p>
      <li data-md>
-      <p>For each <var>client</var> in the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client" id="ref-for-dfn-service-worker-client①">service worker clients</a> for the <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①③">origin</a>:</p>
+      <p>For each <var>client</var> in the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client" id="ref-for-dfn-service-worker-client①">service worker clients</a> for the <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①①">origin</a>:</p>
       <ol>
        <li data-md>
         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type①">frame type</a> is "<code>top-level</code>" or "<code>auxiliary</code>", set <var>isBackground</var> to false.</p>
@@ -1778,24 +1757,24 @@ The user agent should cap the duration and frequency of these events to limit re
      <li data-md>
       <p>If <var>isBackground</var> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject②">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror" id="ref-for-invalidaccesserror">InvalidAccessError</a></code> and abort these steps.</p>
      <li data-md>
-      <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①①">periodic sync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑥">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag">tag</a> equals <var>tag</var> if it exists, else null.</p>
+      <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①⓪">periodic sync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑤">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag">tag</a> equals <var>tag</var> if it exists, else null.</p>
      <li data-md>
       <p>If <var>currentRegistration</var> is null:</p>
       <ol>
        <li data-md>
-        <p>Let <var>newRegistration</var> be a new <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①②">periodic sync registration</a>.</p>
+        <p>Let <var>newRegistration</var> be a new <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①①">periodic sync registration</a>.</p>
        <li data-md>
-        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag①">tag</a> to <var>tag</var>.</p>
+        <p>Set <var>newRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag①">tag</a> to <var>tag</var>.</p>
        <li data-md>
-        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval②">minimum interval</a> to <var>options</var>.<var>minInterval</var>.</p>
+        <p>Set <var>newRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval②">minimum interval</a> to <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-backgroundsyncoptions-mininterval" id="ref-for-dom-backgroundsyncoptions-mininterval">minInterval</a></code> member.</p>
        <li data-md>
-        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state①">state</a> to "<code>pending</code>".</p>
+        <p>Set <var>newRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state①">state</a> to "<code>pending</code>".</p>
        <li data-md>
-        <p>Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑥">service worker registration</a> to <var>serviceWorkerRegistration</var>.</p>
+        <p>Set <var>newRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration④">service worker registration</a> to <var>serviceWorkerRegistration</var>.</p>
        <li data-md>
-        <p>Add <var>newRegistration</var> to <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑦">active periodic sync registrations</a>.</p>
+        <p>Set <var>newRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-anchor-time" id="ref-for-periodic-sync-registration-anchor-time①">anchor time</a> to a timestamp representing now.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire①">Calculate a time to fire</a> for <var>newRegistration</var>.</p>
+        <p>Add <var>newRegistration</var> to <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑥">active periodic sync registrations</a>.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve">Resolve</a> <var>promise</var>.</p>
       </ol>
@@ -1803,12 +1782,10 @@ The user agent should cap the duration and frequency of these events to limit re
       <p>Else:</p>
       <ol>
        <li data-md>
-        <p>If <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval③">minimum interval</a> is different to <var>options</var>.<var>minInterval</var>:</p>
+        <p>If <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval③">minimum interval</a> is different to <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-backgroundsyncoptions-mininterval" id="ref-for-dom-backgroundsyncoptions-mininterval①">minInterval</a></code> member:</p>
         <ol>
          <li data-md>
-          <p>Set <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval④">minimum interval</a> <var>options</var>.<var>minInterval</var>.</p>
-         <li data-md>
-          <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire②">Calculate a time to fire</a> for <var>newRegistration</var>.</p>
+          <p>Set <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-minimum-interval" id="ref-for-periodic-sync-registration-minimum-interval④">minimum interval</a> to <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-backgroundsyncoptions-mininterval" id="ref-for-dom-backgroundsyncoptions-mininterval②">minInterval</a></code> member.</p>
         </ol>
        <li data-md>
         <p>Else, if <var>currentRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state②">state</a> is "<code>firing</code>", set <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state③">state</a> to "<code>reregistered-while-firing</code>".</p>
@@ -1825,7 +1802,7 @@ The user agent should cap the duration and frequency of these events to limit re
      <li data-md>
       <p>Let <var>currentTags</var> be a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a>.</p>
      <li data-md>
-      <p>For each <var>registration</var> of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑧">active periodic sync registrations</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag②">tag</a> to <var>currentTags</var>.</p>
+      <p>For each <var>registration</var> of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑦">active periodic sync registrations</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag②">tag</a> to <var>currentTags</var>.</p>
      <li data-md>
       <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#resolve" id="ref-for-resolve②">Resolve</a> <var>promise</var> with <var>currentTags</var>.</p>
     </ol>
@@ -1837,9 +1814,9 @@ The user agent should cap the duration and frequency of these events to limit re
       <p>Let <var>serviceWorkerRegistration</var> be the <a data-link-type="dfn" href="#periodicsyncmanager-service-worker-registration" id="ref-for-periodicsyncmanager-service-worker-registration③">service worker registration</a> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object④">context object</a>'s <code class="idl"><a data-link-type="idl" href="#periodicsyncmanager" id="ref-for-periodicsyncmanager⑦">PeriodicSyncManager</a></code>.</p>
       <ol>
        <li data-md>
-        <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①③">periodic sync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑨">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag③">tag</a> equals <var>tag</var> if it exists, else null.</p>
+        <p>Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①②">periodic sync registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑧">active periodic sync registrations</a> whose <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag③">tag</a> equals <var>tag</var> if it exists, else null.</p>
        <li data-md>
-        <p>If <var>currentRegistration</var> is not null, remove <var>currentRegistration</var> from <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①⓪">active periodic sync registrations</a>.</p>
+        <p>If <var>currentRegistration</var> is not null, remove <var>currentRegistration</var> from <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations⑨">active periodic sync registrations</a>.</p>
        <li data-md>
         <p>Resolve <var>promise</var>.</p>
       </ol>
@@ -1861,74 +1838,71 @@ The user agent should cap the duration and frequency of these events to limit re
   The <dfn class="dfn-paneled idl-code" data-dfn-for="PeriodicSyncEvent" data-dfn-type="attribute" data-export id="dom-periodicsyncevent-tag"><code>tag</code></dfn> attribute must return the value it was initialized to. </div>
    <h4 class="heading settled" data-level="8.4.1" id="firing-a-periodicsync-event"><span class="secno">8.4.1. </span><span class="content"><a data-link-type="dfn" href="#fire-a-periodicsync-event" id="ref-for-fire-a-periodicsync-event①">Fire a periodicsync event</a></span><a class="self-link" href="#firing-a-periodicsync-event"></a></h4>
     Note: A user agent MAY impose a time limit on the lifetime extension and execution time of a <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent①">PeriodicSyncEvent</a></code> which is stricter than the time limit imposed for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent①">ExtendableEvent</a></code>s in general. In particular, any retries of the <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent②">PeriodicSyncEvent</a></code> MAY have a significantly shortened time limit. 
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fire-a-periodicsync-event">fire a periodicsync event</dfn> for a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①④">periodic sync registration</a> <var>registration</var>, the user agent MUST run the following steps:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>serviceWorkerRegistration</var> be <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑦">service worker registration</a>.</p>
-    <li data-md>
-     <p>If <var>registration</var> is no longer part of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①①">active periodic sync registrations</a>, abort these steps.</p>
-    <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state④">state</a> is "<code>pending</code>".</p>
-    <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-time-to-fire" id="ref-for-periodic-sync-registration-time-to-fire⑤">time to fire</a> is equal to the current time or in the past.</p>
-    <li data-md>
-     <p>Let retryCount be 0.</p>
-    <li data-md>
-     <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state⑤">state</a> to "<code>firing</code>".</p>
-    <li data-md>
-     <p>While true:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>continue</var> be false.</p>
-      <li data-md>
-       <p>Let <var>success</var> be false.</p>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#fire-functional-event" id="ref-for-fire-functional-event">Fire functional event</a> "<code>periodicsync</code>" using <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent③">PeriodicSyncEvent</a></code> on <var>serviceWorkerRegistration</var> with <a data-link-type="dfn" href="#periodicsyncevent-tag" id="ref-for-periodicsyncevent-tag">tag</a> set to <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag⑤">tag</a>. Let <var>dispatchedEvent</var>, an <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent②">ExtendableEvent</a></code>, represent the dispatched <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②①">periodicsync event</a> and run the following steps with <var>dispatchedEvent</var>:</p>
-      <li data-md>
-       <p>Let <var>waitUntilPromise</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#wait-for-all" id="ref-for-wait-for-all">waiting for all</a> of <var>dispatchedEvent</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises">extend lifetime promises</a>.</p>
-      <li data-md>
-       <p>React to the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-fulfillment" id="ref-for-upon-fulfillment">fulfillment</a> of <var>waitUntilPromise</var> with the following steps:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>success</var> to true.</p>
-        <li data-md>
-         <p>Set <var>continue</var> to true.</p>
-       </ol>
-      <li data-md>
-       <p>React to rejection <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-rejection" id="ref-for-upon-rejection">rejection</a> of <var>waitUntilPromise</var> with the following steps:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>continue</var> to true.</p>
-       </ol>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">In parallel</a>:</p>
-       <ol>
-        <li data-md>
-         <p>Wait for <var>continue</var> to be true.</p>
-        <li data-md>
-         <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①④">origin</a> associated with <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑧">service worker registration</a>.</p>
-        <li data-md>
-         <p>If <var>success</var> is true, set <a data-link-type="dfn" href="#periodic-sync-scheduler-time-of-last-fire" id="ref-for-periodic-sync-scheduler-time-of-last-fire①">time of last fire</a> for key <var>origin</var> to the current time.</p>
-        <li data-md>
-         <p>If <var>success</var> is true or <var>retryCount</var> is greater than <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries①">maximum number of retries</a> or <var>registration</var>’s state is "<code>reregistered-while-firing</code>", then:</p>
-         <ol>
-          <li data-md>
-           <p>
-            Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state⑥">state</a> to "
-            <cod>pending`".</cod>
-           </p>
-          <li data-md>
-           <p><a data-link-type="dfn" href="#calculate-a-time-to-fire" id="ref-for-calculate-a-time-to-fire③">Calculate a time to fire</a> for <var>registration</var>.</p>
-          <li data-md>
-           <p>Abort these steps.</p>
-         </ol>
-       </ol>
-      <li data-md>
-       <p>Increment <var>retryCount</var>.</p>
-      <li data-md>
-       <p>Wait for a small back-off time based on <var>retryCount</var>.</p>
-     </ol>
-   </ol>
+   <div class="algorithm" data-algorithm="fire a periodicsync event">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fire-a-periodicsync-event">fire a periodicsync event</dfn> for a <a data-link-type="dfn" href="#periodic-sync-registration" id="ref-for-periodic-sync-registration①③">periodic sync registration</a> <var>registration</var>, the user agent MUST run the following steps: 
+    <ol>
+     <li data-md>
+      <p>Let <var>serviceWorkerRegistration</var> be <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑤">service worker registration</a>.</p>
+     <li data-md>
+      <p>If <var>registration</var> is no longer part of <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#active-periodic-sync-registrations" id="ref-for-active-periodic-sync-registrations①⓪">active periodic sync registrations</a>, abort these steps.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state④">state</a> is "<code>pending</code>".</p>
+     <li data-md>
+      <p>Let retryCount be 0.</p>
+     <li data-md>
+      <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state⑤">state</a> to "<code>firing</code>".</p>
+     <li data-md>
+      <p>While true:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>continue</var> be false.</p>
+       <li data-md>
+        <p>Let <var>success</var> be false.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#fire-functional-event" id="ref-for-fire-functional-event">Fire functional event</a> "<code>periodicsync</code>" using <code class="idl"><a data-link-type="idl" href="#periodicsyncevent" id="ref-for-periodicsyncevent③">PeriodicSyncEvent</a></code> on <var>serviceWorkerRegistration</var> with <a data-link-type="dfn" href="#periodicsyncevent-tag" id="ref-for-periodicsyncevent-tag">tag</a> set to <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-tag" id="ref-for-periodic-sync-registration-tag⑤">tag</a>. Let <var>dispatchedEvent</var>, an <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#extendableevent" id="ref-for-extendableevent②">ExtendableEvent</a></code>, represent the dispatched <a data-link-type="dfn" href="#periodicsync-event" id="ref-for-periodicsync-event②⓪">periodicsync event</a> and run the following steps with <var>dispatchedEvent</var>:</p>
+       <li data-md>
+        <p>Let <var>waitUntilPromise</var> be the result of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#wait-for-all" id="ref-for-wait-for-all">waiting for all</a> of <var>dispatchedEvent</var>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises">extend lifetime promises</a>.</p>
+       <li data-md>
+        <p>React to the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-fulfillment" id="ref-for-upon-fulfillment">fulfillment</a> of <var>waitUntilPromise</var> with the following steps:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>success</var> to true.</p>
+         <li data-md>
+          <p>Set <var>continue</var> to true.</p>
+        </ol>
+       <li data-md>
+        <p>React to rejection <a data-link-type="dfn" href="https://heycam.github.io/webidl/#upon-rejection" id="ref-for-upon-rejection">rejection</a> of <var>waitUntilPromise</var> with the following steps:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>continue</var> to true.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">In parallel</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Wait for <var>continue</var> to be true.</p>
+         <li data-md>
+          <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin" id="ref-for-service-worker-client-origin①②">origin</a> associated with <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-service-worker-registration" id="ref-for-periodic-sync-registration-service-worker-registration⑥">service worker registration</a>.</p>
+         <li data-md>
+          <p>If <var>success</var> is true, set <a data-link-type="dfn" href="#periodic-sync-scheduler-time-of-last-fire" id="ref-for-periodic-sync-scheduler-time-of-last-fire①">time of last fire</a> for key <var>origin</var> to the current time.</p>
+         <li data-md>
+          <p>If <var>success</var> is true or <var>retryCount</var> is greater than <a data-link-type="dfn" href="#maximum-number-of-retries" id="ref-for-maximum-number-of-retries①">maximum number of retries</a> or <var>registration</var>’s state is "<code>reregistered-while-firing</code>", then:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-state" id="ref-for-periodic-sync-registration-state⑥">state</a> to "<code>pending</code>".</p>
+           <li data-md>
+            <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#periodic-sync-registration-anchor-time" id="ref-for-periodic-sync-registration-anchor-time②">anchor time</a> to a timestamp representing now.</p>
+           <li data-md>
+            <p>Abort these steps.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>Increment <var>retryCount</var>.</p>
+       <li data-md>
+        <p>Wait for a small back-off time based on <var>retryCount</var>.</p>
+      </ol>
+    </ol>
+   </div>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2080,9 +2054,9 @@ The user agent should cap the duration and frequency of these events to limit re
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#active-periodic-sync-registrations">Active periodic sync registrations</a><span>, in §3</span>
+   <li><a href="#periodic-sync-registration-anchor-time">anchor time</a><span>, in §4.1</span>
    <li><a href="#dictdef-backgroundsyncoptions">BackgroundSyncOptions</a><span>, in §8.3</span>
-   <li><a href="#calculate-a-time-to-fire">Calculate a time to fire</a><span>, in §7.1</span>
-   <li><a href="#periodic-sync-scheduler-effective-minimum-interval">Effective minimum interval</a><span>, in §4.2</span>
+   <li><a href="#effective-minimum-sync-interval-for-origin">effective minimum sync interval for origin</a><span>, in §4.2</span>
    <li><a href="#fire-a-periodicsync-event">fire a periodicsync event</a><span>, in §8.4.1</span>
    <li><a href="#dom-periodicsyncmanager-gettags">getTags()</a><span>, in §8.3</span>
    <li><a href="#periodicsync-event-in-the-background">in the background</a><span>, in §2</span>
@@ -2102,10 +2076,10 @@ The user agent should cap the duration and frequency of these events to limit re
    <li><a href="#periodic-sync-processing-queue">Periodic sync processing queue</a><span>, in §3</span>
    <li><a href="#periodic-sync-registration">periodic sync registration</a><span>, in §4.1</span>
    <li><a href="#periodic-sync-scheduler">Periodic Sync Scheduler</a><span>, in §4.2</span>
-   <li><a href="#process-periodic-sync-registrations">Process periodic sync registrations</a><span>, in §7.2</span>
+   <li><a href="#process-periodic-sync-registrations">Process periodic sync registrations</a><span>, in §7.1</span>
    <li><a href="#dom-periodicsyncmanager-register">register(tag)</a><span>, in §8.3</span>
    <li><a href="#dom-periodicsyncmanager-register">register(tag, options)</a><span>, in §8.3</span>
-   <li><a href="#respond-to-permission-revocation">Respond to permission revocation</a><span>, in §7.3</span>
+   <li><a href="#respond-to-permission-revocation">Respond to permission revocation</a><span>, in §7.2</span>
    <li>
     service worker registration
     <ul>
@@ -2122,7 +2096,6 @@ The user agent should cap the duration and frequency of these events to limit re
      <li><a href="#dom-periodicsynceventinit-tag">dict-member for PeriodicSyncEventInit</a><span>, in §8.4</span>
     </ul>
    <li><a href="#periodic-sync-scheduler-time-of-last-fire">time of last fire</a><span>, in §4.2</span>
-   <li><a href="#periodic-sync-registration-time-to-fire">time to fire</a><span>, in §4.1</span>
    <li><a href="#dom-periodicsyncmanager-unregister">unregister(tag)</a><span>, in §8.3</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-backgroundfetchmanager">
@@ -2159,15 +2132,15 @@ The user agent should cap the duration and frequency of these events to limit re
   <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enqueue-the-following-steps">7.2. Process periodic sync registrations</a>
-    <li><a href="#ref-for-enqueue-the-following-steps①">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-enqueue-the-following-steps">7.1. Process periodic sync registrations</a>
+    <li><a href="#ref-for-enqueue-the-following-steps①">7.2. Respond to permission revocation</a>
     <li><a href="#ref-for-enqueue-the-following-steps②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-enqueue-the-following-steps③">(2)</a> <a href="#ref-for-enqueue-the-following-steps④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-in-parallel">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-in-parallel">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-in-parallel">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-in-parallel①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
@@ -2186,7 +2159,13 @@ The user agent should cap the duration and frequency of these events to limit re
   <aside class="dfn-panel" data-for="term-for-assert">
    <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-assert">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-assert①">(2)</a>
+    <li><a href="#ref-for-assert">8.4.1. Fire a periodicsync event</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-iteration-continue">
+   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-iteration-continue">7.1. Process periodic sync registrations</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list">
@@ -2199,7 +2178,7 @@ The user agent should cap the duration and frequency of these events to limit re
    <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3. Extensions to service worker registration</a>
-    <li><a href="#ref-for-ordered-map①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-ordered-map②">(2)</a> <a href="#ref-for-ordered-map③">(3)</a> <a href="#ref-for-ordered-map④">(4)</a>
+    <li><a href="#ref-for-ordered-map①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-ordered-map②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
@@ -2227,7 +2206,7 @@ The user agent should cap the duration and frequency of these events to limit re
    <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">5.1. Permission</a>
-    <li><a href="#ref-for-dom-permissiondescriptor-name①">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-dom-permissiondescriptor-name①">7.2. Respond to permission revocation</a>
     <li><a href="#ref-for-dom-permissiondescriptor-name②">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
@@ -2298,14 +2277,13 @@ The user agent should cap the duration and frequency of these events to limit re
    <ul>
     <li><a href="#ref-for-service-worker-client-origin">2. Concepts</a>
     <li><a href="#ref-for-service-worker-client-origin①">4.1. Periodic sync registration</a>
-    <li><a href="#ref-for-service-worker-client-origin②">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-service-worker-client-origin③">(2)</a> <a href="#ref-for-service-worker-client-origin④">(3)</a> <a href="#ref-for-service-worker-client-origin⑤">(4)</a>
-    <li><a href="#ref-for-service-worker-client-origin⑥">5.2. Location Tracking</a> <a href="#ref-for-service-worker-client-origin⑦">(2)</a>
-    <li><a href="#ref-for-service-worker-client-origin⑧">6. Resource Usage</a>
-    <li><a href="#ref-for-service-worker-client-origin⑨">7.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-service-worker-client-origin①⓪">7.2. Process periodic sync registrations</a>
-    <li><a href="#ref-for-service-worker-client-origin①①">7.3. Respond to permission revocation</a> <a href="#ref-for-service-worker-client-origin①②">(2)</a>
-    <li><a href="#ref-for-service-worker-client-origin①③">8.3. PeriodicSyncManager interface</a>
-    <li><a href="#ref-for-service-worker-client-origin①④">8.4.1. Fire a periodicsync event</a>
+    <li><a href="#ref-for-service-worker-client-origin②">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-service-worker-client-origin③">(2)</a> <a href="#ref-for-service-worker-client-origin④">(3)</a>
+    <li><a href="#ref-for-service-worker-client-origin⑤">5.2. Location Tracking</a> <a href="#ref-for-service-worker-client-origin⑥">(2)</a>
+    <li><a href="#ref-for-service-worker-client-origin⑦">6. Resource Usage</a>
+    <li><a href="#ref-for-service-worker-client-origin⑧">7.1. Process periodic sync registrations</a>
+    <li><a href="#ref-for-service-worker-client-origin⑨">7.2. Respond to permission revocation</a> <a href="#ref-for-service-worker-client-origin①⓪">(2)</a>
+    <li><a href="#ref-for-service-worker-client-origin①①">8.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-service-worker-client-origin①②">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
@@ -2326,16 +2304,21 @@ The user agent should cap the duration and frequency of these events to limit re
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">4.1. Periodic sync registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration②">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-dfn-service-worker-registration②">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-dfn-service-worker-registration③">8.2. Extensions to the ServiceWorkerRegistration interface</a>
     <li><a href="#ref-for-dfn-service-worker-registration④">8.3. PeriodicSyncManager interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration-unregistered">
+   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-service-worker-registration-unregistered">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-online">
    <a href="https://wicg.github.io/BackgroundSync/spec/#online">https://wicg.github.io/BackgroundSync/spec/#online</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-online">7.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-online①">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-online">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
@@ -2448,6 +2431,7 @@ The user agent should cap the duration and frequency of these events to limit re
     <ul>
      <li><span class="dfn-paneled" id="term-for-list-append" style="color:initial">append</span>
      <li><span class="dfn-paneled" id="term-for-assert" style="color:initial">assert</span>
+     <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-ordered-map" style="color:initial">map</span>
     </ul>
@@ -2480,6 +2464,7 @@ The user agent should cap the duration and frequency of these events to limit re
      <li><span class="dfn-paneled" id="term-for-dfn-service-worker" style="color:initial">service worker</span>
      <li><span class="dfn-paneled" id="term-for-dfn-service-worker-client" style="color:initial">service worker client</span>
      <li><span class="dfn-paneled" id="term-for-dfn-service-worker-registration" style="color:initial">service worker registration</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-service-worker-registration-unregistered" style="color:initial">unregistered</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WEB-BACKGROUND-SYNC]</a> defines the following terms:
@@ -2571,18 +2556,18 @@ The user agent should cap the duration and frequency of these events to limit re
   <aside class="dfn-panel" data-for="active-periodic-sync-registrations">
    <b><a href="#active-periodic-sync-registrations">#active-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-active-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-active-periodic-sync-registrations①">(2)</a> <a href="#ref-for-active-periodic-sync-registrations②">(3)</a>
-    <li><a href="#ref-for-active-periodic-sync-registrations③">7.2. Process periodic sync registrations</a>
-    <li><a href="#ref-for-active-periodic-sync-registrations④">7.3. Respond to permission revocation</a> <a href="#ref-for-active-periodic-sync-registrations⑤">(2)</a>
-    <li><a href="#ref-for-active-periodic-sync-registrations⑥">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-active-periodic-sync-registrations⑦">(2)</a> <a href="#ref-for-active-periodic-sync-registrations⑧">(3)</a> <a href="#ref-for-active-periodic-sync-registrations⑨">(4)</a> <a href="#ref-for-active-periodic-sync-registrations①⓪">(5)</a>
-    <li><a href="#ref-for-active-periodic-sync-registrations①①">8.4.1. Fire a periodicsync event</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-active-periodic-sync-registrations①">(2)</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations②">7.1. Process periodic sync registrations</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations③">7.2. Respond to permission revocation</a> <a href="#ref-for-active-periodic-sync-registrations④">(2)</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations⑤">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-active-periodic-sync-registrations⑥">(2)</a> <a href="#ref-for-active-periodic-sync-registrations⑦">(3)</a> <a href="#ref-for-active-periodic-sync-registrations⑧">(4)</a> <a href="#ref-for-active-periodic-sync-registrations⑨">(5)</a>
+    <li><a href="#ref-for-active-periodic-sync-registrations①⓪">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic-sync-processing-queue">
    <b><a href="#periodic-sync-processing-queue">#periodic-sync-processing-queue</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-sync-processing-queue">7.2. Process periodic sync registrations</a>
-    <li><a href="#ref-for-periodic-sync-processing-queue①">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-periodic-sync-processing-queue">7.1. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-processing-queue①">7.2. Respond to permission revocation</a>
     <li><a href="#ref-for-periodic-sync-processing-queue②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-processing-queue③">(2)</a> <a href="#ref-for-periodic-sync-processing-queue④">(3)</a>
    </ul>
   </aside>
@@ -2595,23 +2580,21 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-periodic-sync-registration③">4.3. Constants</a>
     <li><a href="#ref-for-periodic-sync-registration④">5.1. Permission</a>
     <li><a href="#ref-for-periodic-sync-registration⑤">5.3. History Leaking</a> <a href="#ref-for-periodic-sync-registration⑥">(2)</a>
-    <li><a href="#ref-for-periodic-sync-registration⑦">7.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-periodic-sync-registration⑧">7.2. Process periodic sync registrations</a> <a href="#ref-for-periodic-sync-registration⑨">(2)</a>
-    <li><a href="#ref-for-periodic-sync-registration①⓪">7.3. Respond to permission revocation</a>
-    <li><a href="#ref-for-periodic-sync-registration①①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration①②">(2)</a> <a href="#ref-for-periodic-sync-registration①③">(3)</a>
-    <li><a href="#ref-for-periodic-sync-registration①④">8.4.1. Fire a periodicsync event</a>
+    <li><a href="#ref-for-periodic-sync-registration⑦">7.1. Process periodic sync registrations</a> <a href="#ref-for-periodic-sync-registration⑧">(2)</a>
+    <li><a href="#ref-for-periodic-sync-registration⑨">7.2. Respond to permission revocation</a>
+    <li><a href="#ref-for-periodic-sync-registration①⓪">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration①①">(2)</a> <a href="#ref-for-periodic-sync-registration①②">(3)</a>
+    <li><a href="#ref-for-periodic-sync-registration①③">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic-sync-registration-service-worker-registration">
    <b><a href="#periodic-sync-registration-service-worker-registration">#periodic-sync-registration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration">2. Concepts</a>
-    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration②">(2)</a>
-    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration③">7.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration④">7.2. Process periodic sync registrations</a>
-    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑤">7.3. Respond to permission revocation</a>
-    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑥">8.3. PeriodicSyncManager interface</a>
-    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑦">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration⑧">(2)</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration①">4.2. Periodic Sync Scheduler</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration②">7.1. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration③">7.2. Respond to permission revocation</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration④">8.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑤">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic-sync-registration-tag">
@@ -2626,22 +2609,22 @@ The user agent should cap the duration and frequency of these events to limit re
    <b><a href="#periodic-sync-registration-minimum-interval">#periodic-sync-registration-minimum-interval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval">4.1. Periodic sync registration</a>
-    <li><a href="#ref-for-periodic-sync-registration-minimum-interval①">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-periodic-sync-registration-minimum-interval①">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-minimum-interval③">(2)</a> <a href="#ref-for-periodic-sync-registration-minimum-interval④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-time-to-fire">
-   <b><a href="#periodic-sync-registration-time-to-fire">#periodic-sync-registration-time-to-fire</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="periodic-sync-registration-anchor-time">
+   <b><a href="#periodic-sync-registration-anchor-time">#periodic-sync-registration-anchor-time</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-sync-registration-time-to-fire">7.1. Calculate a time to fire</a> <a href="#ref-for-periodic-sync-registration-time-to-fire①">(2)</a> <a href="#ref-for-periodic-sync-registration-time-to-fire②">(3)</a> <a href="#ref-for-periodic-sync-registration-time-to-fire③">(4)</a>
-    <li><a href="#ref-for-periodic-sync-registration-time-to-fire④">7.2. Process periodic sync registrations</a>
-    <li><a href="#ref-for-periodic-sync-registration-time-to-fire⑤">8.4.1. Fire a periodicsync event</a>
+    <li><a href="#ref-for-periodic-sync-registration-anchor-time">7.1. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-registration-anchor-time①">8.3. PeriodicSyncManager interface</a>
+    <li><a href="#ref-for-periodic-sync-registration-anchor-time②">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodic-sync-registration-state">
    <b><a href="#periodic-sync-registration-state">#periodic-sync-registration-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-sync-registration-state">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-registration-state">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-state①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-state②">(2)</a> <a href="#ref-for-periodic-sync-registration-state③">(3)</a>
     <li><a href="#ref-for-periodic-sync-registration-state④">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-state⑤">(2)</a> <a href="#ref-for-periodic-sync-registration-state⑥">(3)</a>
    </ul>
@@ -2655,29 +2638,29 @@ The user agent should cap the duration and frequency of these events to limit re
   <aside class="dfn-panel" data-for="periodic-sync-scheduler-time-of-last-fire">
    <b><a href="#periodic-sync-scheduler-time-of-last-fire">#periodic-sync-scheduler-time-of-last-fire</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-scheduler-effective-minimum-interval">
-   <b><a href="#periodic-sync-scheduler-effective-minimum-interval">#periodic-sync-scheduler-effective-minimum-interval</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="effective-minimum-sync-interval-for-origin">
+   <b><a href="#effective-minimum-sync-interval-for-origin">#effective-minimum-sync-interval-for-origin</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-periodic-sync-scheduler-effective-minimum-interval">7.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-periodic-sync-scheduler-effective-minimum-interval①">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-effective-minimum-sync-interval-for-origin">4.2. Periodic Sync Scheduler</a>
+    <li><a href="#ref-for-effective-minimum-sync-interval-for-origin①">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-for-any-origin">
    <b><a href="#minimum-periodic-sync-interval-for-any-origin">#minimum-periodic-sync-interval-for-any-origin</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin①">(2)</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin②">(3)</a>
-    <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin③">7.1. Calculate a time to fire</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin">4.2. Periodic Sync Scheduler</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin①">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin②">(2)</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-across-origins">
    <b><a href="#minimum-periodic-sync-interval-across-origins">#minimum-periodic-sync-interval-across-origins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-across-origins①">(2)</a>
-    <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins②">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins②">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="maximum-number-of-retries">
@@ -2685,14 +2668,6 @@ The user agent should cap the duration and frequency of these events to limit re
    <ul>
     <li><a href="#ref-for-maximum-number-of-retries">4.3. Constants</a>
     <li><a href="#ref-for-maximum-number-of-retries①">8.4.1. Fire a periodicsync event</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="calculate-a-time-to-fire">
-   <b><a href="#calculate-a-time-to-fire">#calculate-a-time-to-fire</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-calculate-a-time-to-fire">4.1. Periodic sync registration</a>
-    <li><a href="#ref-for-calculate-a-time-to-fire①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-calculate-a-time-to-fire②">(2)</a>
-    <li><a href="#ref-for-calculate-a-time-to-fire③">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="process-periodic-sync-registrations">
@@ -2704,7 +2679,7 @@ The user agent should cap the duration and frequency of these events to limit re
   <aside class="dfn-panel" data-for="respond-to-permission-revocation">
    <b><a href="#respond-to-permission-revocation">#respond-to-permission-revocation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-respond-to-permission-revocation">7.3. Respond to permission revocation</a>
+    <li><a href="#ref-for-respond-to-permission-revocation">7.2. Respond to permission revocation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkerregistration-periodic-sync-manager">
@@ -2730,6 +2705,12 @@ The user agent should cap the duration and frequency of these events to limit re
    <b><a href="#dictdef-backgroundsyncoptions">#dictdef-backgroundsyncoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-backgroundsyncoptions">8.3. PeriodicSyncManager interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-backgroundsyncoptions-mininterval">
+   <b><a href="#dom-backgroundsyncoptions-mininterval">#dom-backgroundsyncoptions-mininterval</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-backgroundsyncoptions-mininterval">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-dom-backgroundsyncoptions-mininterval①">(2)</a> <a href="#ref-for-dom-backgroundsyncoptions-mininterval②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="periodicsyncmanager-service-worker-registration">
@@ -2769,8 +2750,7 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-periodicsync-event①①">5.2. Location Tracking</a> <a href="#ref-for-periodicsync-event①②">(2)</a> <a href="#ref-for-periodicsync-event①③">(3)</a>
     <li><a href="#ref-for-periodicsync-event①④">5.3. History Leaking</a> <a href="#ref-for-periodicsync-event①⑤">(2)</a> <a href="#ref-for-periodicsync-event①⑥">(3)</a> <a href="#ref-for-periodicsync-event①⑦">(4)</a>
     <li><a href="#ref-for-periodicsync-event①⑧">6. Resource Usage</a> <a href="#ref-for-periodicsync-event①⑨">(2)</a>
-    <li><a href="#ref-for-periodicsync-event②⓪">7.1. Calculate a time to fire</a>
-    <li><a href="#ref-for-periodicsync-event②①">8.4.1. Fire a periodicsync event</a>
+    <li><a href="#ref-for-periodicsync-event②⓪">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-periodicsynceventinit">
@@ -2801,7 +2781,7 @@ The user agent should cap the duration and frequency of these events to limit re
   <aside class="dfn-panel" data-for="fire-a-periodicsync-event">
    <b><a href="#fire-a-periodicsync-event">#fire-a-periodicsync-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fire-a-periodicsync-event">7.2. Process periodic sync registrations</a>
+    <li><a href="#ref-for-fire-a-periodicsync-event">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-fire-a-periodicsync-event①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>


### PR DESCRIPTION
@jakearchibald, thanks for the thorough review of the spec, much appreciated!
PTAL at the changes I have made in response.

Some comments:
1. Because I have added a "respond to permission revocation" section which removes the affected registrations from active registrations, I'm not checking for the permission before each event is to be fired, and instead checking if the registration still exists in "active registrations".
2. reregisteredwhilefiring has more references now, specifically it's being used to reset count of retries.
3. Per your recommendation, I have removed options definition and any clarification as to why it's a dictionary since you say it's a common paradigm for APIs.
4. I'm referring to "online" from the Web Background sync spec.
5. There are two queues now, one for the scheduler and one for keeping track of registrations.
6. I have spec'ed a scheduler describing and made various algorithms around scheduling more specific while providing leeway to the user agent in setting of various constants to tweak these algos. I have also provided default values for these constants for purposes of algorithms in this spec.
7. "minimum interval for any origin" is one such constant, it applies caps on frequency on a per origin basis. "minimum interval across all origins" applies global caps on frequency.
8. PTAL a look at the constructors for PeriodicSyncManager and PeriodicSyncEvent, I'm not sure I quite understand how you suggested using SameObject.
9. I have used "in parallel" around waits because I'd like to free up the processing queue for more operations and the wait can be asynchronous on a background thread.