### PR TITLE
Update the definition of a sync event running "in the background".

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9,6 +9,7 @@ Editor: Marijn Kruisselbrink, Google, mek@chromium.org
 Abstract: This specification describes a method that enables web applications to synchronize data in the background.
 Group: wicg
 Repository: WICG/BackgroundSync
+Markup Shorthands: css no, markdown yes
 Link Defaults: html (dfn) allowed to show a popup/event handler idl attribute/global object/in parallel/incumbent settings object/perform a microtask checkpoint/queue a task/script execution environment
 </pre>
 
@@ -145,7 +146,7 @@ spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
 <section>
   <h2 id="concepts">Concepts</h2>
 
-  The sync event is considered to run <dfn>in the background</dfn> if no <a>service worker clients</a> whose <a>frame type</a> is top-level or auxiliary exist for the origin of the corresponding service worker registration.
+  The sync event is considered to run <dfn>in the background</dfn> if no <a>service worker clients</a> whose <a>frame type</a> is "`top-level`" or "`auxiliary`" or "`nested`" exist for the origin of the corresponding service worker registration.
 
   The user agent is considered to be <dfn>online</dfn> if the user agent has established a network connection. A user agent MAY use a stricter definition of being <a>online</a>. Such a stricter definition MAY take into account the particular <a>service worker</a> or origin a <a>sync registration</a> is associated with.
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1029,7 +1029,7 @@ Possible extra rowspan handling
 		}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;
@@ -1212,9 +1212,10 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 30dbdcf66519991ec52011cac10c49a7b5b449c5" name="generator">
+  <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version 60a9f27730c0c9ae3e20485f824cef3713caf5fb" name="generator">
   <link href="https://wicg.github.io/BackgroundSync/spec/" rel="canonical">
-  <meta content="edee56599d6f1130759457a5d51aefd433a639c1" name="document-revision">
+  <meta content="c12f61864456f0836226271f5ce5a6468b365f3e" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1461,7 +1462,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Background Synchronization</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-11-07">7 November 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-12-05">5 December 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1474,7 +1475,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 the Contributors to the Web Background Synchronization Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2019 the Contributors to the Web Background Synchronization Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
@@ -1581,7 +1582,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    </section>
    <section>
     <h2 class="heading settled" data-level="2" id="concepts"><span class="secno">2. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
-    <p>The sync event is considered to run <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="in-the-background">in the background</dfn> if no <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client" id="ref-for-dfn-service-worker-client">service worker clients</a> whose <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type">frame type</a> is top-level or auxiliary exist for the origin of the corresponding service worker registration.</p>
+    <p>The sync event is considered to run <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="in-the-background">in the background</dfn> if no <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client" id="ref-for-dfn-service-worker-client">service worker clients</a> whose <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type" id="ref-for-dfn-service-worker-client-frame-type">frame type</a> is "<code>top-level</code>" or "<code>auxiliary</code>" or "<code>nested</code>" exist for the origin of the corresponding service worker registration.</p>
     <p>The user agent is considered to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="online">online</dfn> if the user agent has established a network connection. A user agent MAY use a stricter definition of being <a data-link-type="dfn" href="#online" id="ref-for-online">online</a>. Such a stricter definition MAY take into account the particular <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept" id="ref-for-service-worker-concept②">service worker</a> or origin a <a data-link-type="dfn" href="#sync-registration" id="ref-for-sync-registration">sync registration</a> is associated with.</p>
    </section>
    <section>
@@ -1673,8 +1674,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler"><c- n>EventHandler</c-></a> <dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export data-type="EventHandler" id="dom-serviceworkerglobalscope-onsync"><code><c- g>onsync</c-></code><a class="self-link" href="#dom-serviceworkerglobalscope-onsync"></a></dfn>;
 };
 
-[<dfn class="idl-code" data-dfn-for="SyncEvent" data-dfn-type="constructor" data-export data-lt="SyncEvent(type, init)" id="dom-syncevent-syncevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-syncevent-syncevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SyncEvent/SyncEvent(type, init)" data-dfn-type="argument" data-export id="dom-syncevent-syncevent-type-init-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-syncevent-syncevent-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-synceventinit" id="ref-for-dictdef-synceventinit"><c- n>SyncEventInit</c-></a> <dfn class="idl-code" data-dfn-for="SyncEvent/SyncEvent(type, init)" data-dfn-type="argument" data-export id="dom-syncevent-syncevent-type-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-syncevent-syncevent-type-init-init"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="syncevent"><code><c- g>SyncEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface" id="ref-for-extendable-event-interface"><c- n>ExtendableEvent</c-></a> {
+  <dfn class="idl-code" data-dfn-for="SyncEvent" data-dfn-type="constructor" data-export data-lt="SyncEvent(type, init)|constructor(type, init)" id="dom-syncevent-syncevent"><code><c- g>constructor</c-></code><a class="self-link" href="#dom-syncevent-syncevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SyncEvent/constructor(type, init)" data-dfn-type="argument" data-export id="dom-syncevent-constructor-type-init-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-syncevent-constructor-type-init-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-synceventinit" id="ref-for-dictdef-synceventinit"><c- n>SyncEventInit</c-></a> <dfn class="idl-code" data-dfn-for="SyncEvent/constructor(type, init)" data-dfn-type="argument" data-export id="dom-syncevent-constructor-type-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-syncevent-constructor-type-init-init"></a></dfn>);
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SyncEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-syncevent-tag"><code><c- g>tag</c-></code></dfn>;
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SyncEvent" data-dfn-type="attribute" data-export data-readonly data-type="boolean" id="dom-syncevent-lastchance"><code><c- g>lastChance</c-></code></dfn>;
 };
@@ -1910,6 +1912,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
+   <li><a href="#dom-syncevent-syncevent">constructor(type, init)</a><span>, in §5.3</span>
    <li><a href="#fire-a-sync-event">fire a sync event</a><span>, in §5.3</span>
    <li><a href="#firing">firing</a><span>, in §3</span>
    <li><a href="#dom-syncmanager-gettags">getTags()</a><span>, in §5.2</span>
@@ -2199,7 +2202,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
-   <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
+   <dd><a href="https://tc39.es/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-promises-guide">[PROMISES-GUIDE]
@@ -2209,9 +2212,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
    <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-service-workers-1">[SERVICE-WORKERS-1]
-   <dd>Alex Russell; et al. <a href="https://www.w3.org/TR/service-workers-1/">Service Workers 1</a>. 2 November 2017. WD. URL: <a href="https://www.w3.org/TR/service-workers-1/">https://www.w3.org/TR/service-workers-1/</a>
+   <dd>Alex Russell; et al. <a href="https://www.w3.org/TR/service-workers-1/">Service Workers 1</a>. 19 November 2019. CR. URL: <a href="https://www.w3.org/TR/service-workers-1/">https://www.w3.org/TR/service-workers-1/</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface" id="ref-for-service-worker-registration-interface①①"><c- g>ServiceWorkerRegistration</c-></a> {
@@ -2228,8 +2231,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler①"><c- n>EventHandler</c-></a> <a data-type="EventHandler" href="#dom-serviceworkerglobalscope-onsync"><code><c- g>onsync</c-></code></a>;
 };
 
-[<a href="#dom-syncevent-syncevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a href="#dom-syncevent-syncevent-type-init-type"><code><c- g>type</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-synceventinit" id="ref-for-dictdef-synceventinit①"><c- n>SyncEventInit</c-></a> <a href="#dom-syncevent-syncevent-type-init-init"><code><c- g>init</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
 <c- b>interface</c-> <a href="#syncevent"><code><c- g>SyncEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface" id="ref-for-extendable-event-interface②"><c- n>ExtendableEvent</c-></a> {
+  <a href="#dom-syncevent-syncevent"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a href="#dom-syncevent-constructor-type-init-type"><code><c- g>type</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-synceventinit" id="ref-for-dictdef-synceventinit①"><c- n>SyncEventInit</c-></a> <a href="#dom-syncevent-constructor-type-init-init"><code><c- g>init</c-></code></a>);
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a> <a data-readonly data-type="DOMString" href="#dom-syncevent-tag"><code><c- g>tag</c-></code></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-syncevent-lastchance"><code><c- g>lastChance</c-></code></a>;
 };


### PR DESCRIPTION
This now excludes the case when the event is running and there's at
least one nested frame for the origin. A nested frame will have a window
client and thus running a sync event for these won't cause the privacy
concerns this definition is used to describe.

This change also aligns this spec with the Periodic Background Sync
prose.