### PR TITLE
Define background-sync as a default powerful feature.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -166,6 +166,12 @@ spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
 </section>
 
 <section>
+  <h2 id="permissions-integration">Permissions Integration</h2>
+  The Web Background Synchronization API is a [=default powerful feature=] that is identified by the
+  [=powerful feature/name=] "background-sync".
+</section>
+
+<section>
   <h2 id="privacy-considerations">Privacy Considerations</h2>
 
   <section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -3,10 +3,1334 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>Web Background Synchronization</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     + <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<nav id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .assertion  for assertions                    (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure) " ";  }
+ *        .example::before { content: "Example " counter(example) " "; }
+ *        .issue::before   { content: "Issue "   counter(issue) " ";   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - js-added ToC jump links (see fixup.js)
+ *
+ ******************************************************************************/
+
+/* color variables included separately for reliability */
+
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
+
+	html {
+		color: black;
+		color: var(--text);
+		background-color: white;
+		background-color: var(--bg);
+	}
+
+	body {
+		counter-reset: example figure issue;
+
+		/* Layout */
+		max-width: 50em;               /* limit line length to 50em for readability   */
+		margin: 0 auto;                /* center text within page                     */
+		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
+
+		/* Typography */
+		line-height: 1.5;
+		font-family: sans-serif;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
+
+		background: transparent top left fixed no-repeat;
+		background-size: 25px auto;
+	}
+
+
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
+
+/** Header ********************************************************************/
+
+	div.head { margin-bottom: 1em }
+	div.head hr { border-style: solid; }
+
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
+	}
+
+	div.head h2 { margin-bottom: 1.5em;}
+
+/** W3C Logo ******************************************************************/
+
+	.head .logo {
+		float: right;
+		margin: 0.4rem 0 0.2rem .4rem;
+	}
+
+	.head img[src*="logos/W3C"] {
+		display: block;
+		border: solid #1a5e9a;
+		border: solid var(--logo-bg);
+		border-width: .65rem .7rem .6rem;
+		border-radius: .4rem;
+		background: #1a5e9a;
+		background: var(--logo-bg);
+		color: white;
+		color: var(--logo-text);
+		font-weight: bold;
+	}
+
+	.head a:hover > img[src*="logos/W3C"],
+	.head a:focus > img[src*="logos/W3C"] {
+		opacity: .8;
+	}
+
+	.head a:active > img[src*="logos/W3C"] {
+		background: #c00;
+		background: var(--logo-active-bg);
+		border-color: #c00;
+		border-color: var(--logo-active-bg);
+	}
+
+	/* see also additional rules in Link Styling section */
+
+/** Copyright *****************************************************************/
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#toc-nav {
+			display: none;
+		}
+	}
+	@media not print {
+		#toc-nav {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			min-width: 1.33em;
+			border-top-right-radius: 2rem;
+			box-shadow: 0 0 2px;
+			font-size: 1.5em;
+		}
+		#toc-nav > a {
+			display: block;
+			white-space: nowrap;
+
+			height: 1.33em;
+			padding: .1em 0.3em;
+			margin: 0;
+
+			box-shadow: 0 0 2px;
+			border: none;
+			border-top-right-radius: 1.33em;
+
+			color: #707070;
+			color: var(--tocnav-normal-text);
+			background: white;
+			background: var(--tocnav-normal-bg);
+		}
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			color: black;
+			color: var(--tocnav-hover-text);
+			background: #f8f8f8;
+			background: var(--tocnav-hover-bg);
+		}
+		#toc-nav > a:active {
+			color: #c00;
+			color: var(--tocnav-active-text);
+			background: white;
+			background: var(--tocnav-active-bg);
+		}
+
+		#toc-nav > #toc-jump {
+			padding-bottom: 2em;
+			margin-bottom: -1.9em;
+		}
+
+		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
+		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
+			padding-bottom: 1.5rem;
+		}
+
+		#toc-nav:not(:hover) > a:not(:focus) > span + span {
+			/* Ideally this uses :focus-within on #toc-nav */
+			display: none;
+		}
+		#toc-nav > a > span + span {
+			padding-right: 0.2em;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			max-width: 80%;
+			max-width: calc(100% - 2em - 26px);
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			color: black;
+			color: var(--tocsidebar-text);
+			background: inherit;
+			background-color: #f7f8f9;
+			background-color: var(--tocsidebar-bg);
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+			box-shadow: -.1em 0 .25em var(--tocsidebar-shadow) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			color: var(--tocsidebar-heading-text);
+		}
+		body.toc-sidebar #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	/* Hide main scroller when only the ToC is visible anyway */
+	@media screen and (max-width: 28em) {
+		body.toc-sidebar {
+			overflow: hidden;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			color: black;
+			color: var(--tocsidebar-text);
+			background: inherit;
+			background-color: #f7f8f9;
+			background-color: var(--tocsidebar-bg);
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+			box-shadow: -.1em 0 .25em var(--tocsidebar-shadow) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			color: var(--tocsidebar-heading-text);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+		}
+		/* See also Overflow section at the bottom */
+
+		body:not(.toc-inline) #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) {
+			margin: 0 4em;
+		}
+	}
+
+/******************************************************************************/
+/*                                Sectioning                                  */
+/******************************************************************************/
+
+/** Headings ******************************************************************/
+
+	h1, h2, h3, h4, h5, h6, dt {
+		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
+		hyphens: manual;         /* Hyphenated headings look weird */
+	}
+
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
+	}
+
+	h1, h2, h3 {
+		color: #005A9C;
+		color: var(--heading-text);
+	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
+
+/** Subheadings ***************************************************************/
+
+	h1 + h2,
+	#subtitle {
+		/* #subtitle is a subtitle in an H2 under the H1 */
+		margin-top: 0;
+	}
+	h2 + h3,
+	h3 + h4,
+	h4 + h5,
+	h5 + h6 {
+		margin-top: 1.2em; /* = 1 x line-height */
+	}
+
+/** Section divider ***********************************************************/
+
+	:not(.head) > :not(.head) + hr {
+		font-size: 1.5em;
+		text-align: center;
+		margin: 1em auto;
+		height: auto;
+		color: black;
+		color: var(--hr-text);
+		border: transparent solid 0;
+		background: transparent;
+	}
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
+	}
+
+/******************************************************************************/
+/*                            Paragraphs and Lists                            */
+/******************************************************************************/
+
+	p {
+		margin: 1em 0;
+	}
+
+	dd > p:first-child,
+	li > p:first-child {
+		margin-top: 0;
+	}
+
+	ul, ol {
+		margin-left: 0;
+		padding-left: 2em;
+	}
+
+	li {
+		margin: 0.25em 0 0.5em;
+		padding: 0;
+	}
+
+	dl dd {
+		margin: 0 0 .5em 2em;
+	}
+
+	.head dd + dd { /* compact for header */
+		margin-top: -.5em;
+	}
+
+	/* Style for algorithms */
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
+	 border-left: 0.5em solid var(--algo-border);
+	}
+
+	/* Put nice boxes around each algorithm. */
+	[data-algorithm]:not(.heading) {
+	  padding: .5em;
+	  border: thin solid #ddd;
+	  border: thin solid var(--algo-border);
+	  border-radius: .5em;
+	  margin: .5em calc(-0.5em - 1px);
+	}
+	[data-algorithm]:not(.heading) > :first-child {
+	  margin-top: 0;
+	}
+	[data-algorithm]:not(.heading) > :last-child {
+	  margin-bottom: 0;
+	}
+
+	/* Style for switch/case <dl>s */
+	dl.switch > dd > ol.only,
+	dl.switch > dd > .only > ol {
+	 margin-left: 0;
+	}
+	dl.switch > dd > ol.algorithm,
+	dl.switch > dd > .algorithm > ol {
+	 margin-left: -2em;
+	}
+	dl.switch {
+	 padding-left: 2em;
+	}
+	dl.switch > dt {
+	 text-indent: -1.5em;
+	 margin-top: 1em;
+	}
+	dl.switch > dt + dt {
+	 margin-top: 0;
+	}
+	dl.switch > dt::before {
+	 content: '\21AA';
+	 padding: 0 0.5em 0 0;
+	 display: inline-block;
+	 width: 1em;
+	 text-align: right;
+	 line-height: 0.5em;
+	}
+
+/** Terminology Markup ********************************************************/
+
+
+/******************************************************************************/
+/*                                 Inline Markup                              */
+/******************************************************************************/
+
+/** Terminology Markup ********************************************************/
+	dfn   { /* Defining instance */
+		font-weight: bolder;
+	}
+	a > i { /* Instance of term */
+		font-style: normal;
+	}
+	dt dfn code, code.idl {
+		font-size: medium;
+	}
+	dfn var {
+		font-style: normal;
+	}
+
+/** Change Marking ************************************************************/
+
+	del {
+		color: red;
+		color: var(--del-text);
+		background: transparent;
+		background: var(--del-bg);
+		text-decoration: line-through;
+	}
+	ins {
+		color: #080;
+		color: var(--ins-text);
+		background: transparent;
+		background: var(--ins-bg);
+		text-decoration: underline;
+	}
+
+/** Miscellaneous improvements to inline formatting ***************************/
+
+	sup {
+		vertical-align: super;
+		font-size: 80%
+	}
+
+/******************************************************************************/
+/*                                    Code                                    */
+/******************************************************************************/
+
+/** General monospace/pre rules ***********************************************/
+
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+		font-size: .9em;
+		hyphens: none;
+		text-transform: none;
+		text-align: left;
+		text-align: start;
+		font-variant: normal;
+		orphans: 3;
+		widows: 3;
+		page-break-before: avoid;
+	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
+	pre {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		overflow: auto;
+	}
+
+/** Inline Code fragments *****************************************************/
+
+  /* Do something nice. */
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a[href] {
+		color: #034575;
+		color: var(--a-normal-text);
+		text-decoration: none;
+		border-bottom: 1px solid #707070;
+		border-bottom: 1px solid var(--a-normal-underline);
+		/* Need a bit of extending for it to look okay */
+		padding: 0 1px 0;
+		margin: 0 -1px 0;
+	}
+	a:visited {
+		color: #034575;
+		color: var(--a-visited-text);
+		border-bottom-color: #bbb;
+		border-bottom-color: var(--a-visited-underline);
+	}
+
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		background: var(--a-hover-bg);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
+	}
+	a[href]:active {
+		color: #c00;
+		color: var(--a-active-text);
+		border-color: #c00;
+		border-color: var(--a-active-underline);
+	}
+
+	/* Backout above styling for W3C logo */
+	.head .logo,
+	.head .logo a {
+		border: none;
+		text-decoration: none;
+		background: transparent;
+	}
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+	}
+
+	img, svg {
+		/* Intentionally not color-scheme aware. */
+		background: white;
+	}
+
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
+
+	figure, .figure, .sidefigure {
+		page-break-inside: avoid;
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	.figure img,    .sidefigure img,    figure img,
+	.figure object, .sidefigure object, figure object {
+		max-width: 100%;
+		margin: auto;
+		height: auto;
+	}
+	.figure pre, .sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	@media screen and (min-width: 20em) {
+		.sidefigure {
+			float: right;
+			width: 50%;
+			margin: 0 0 0.5em 0.5em
+		}
+	}
+	.caption, figcaption, caption {
+		font-style: italic;
+		font-size: 90%;
+	}
+	.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > .figure, dd > figure { margin-left: -2em }
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .assertion, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	.issue,
+	.note,
+	.example,
+	.advisement,
+	.assertion,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+
+	.issue::before, .issue > .marker,
+	.example::before, .example > .marker,
+	.note::before, .note > .marker,
+	details.note > summary > .marker {
+		text-transform: uppercase;
+		padding-right: 1em;
+	}
+
+	.example::before, .example > .marker {
+		display: block;
+		padding-right: 0em;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+		border-color: var(--blockquote-border);
+		background: transparent;
+		background: var(--blockquote-bg);
+		color: currentcolor;
+		color: var(--blockquote-text);
+	}
+
+/** Open issue ****************************************************************/
+
+	.issue {
+		border-color: #e05252;
+		border-color: var(--issue-border);
+		background: #fbe9e9;
+		background: var(--issue-bg);
+		color: black;
+		color: var(--issue-text);
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue::before, .issue > .marker {
+		color: #831616;
+		color: var(--issueheading-text);
+	}
+	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #e0cb52;
+		border-color: var(--example-border);
+		background: #fcfaee;
+		background: var(--example-bg);
+		color: black;
+		color: var(--example-text);
+		counter-increment: example;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		color: #574b0f;
+		color: var(--exampleheading-text);
+	}
+	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
+
+/** Non-normative Note ********************************************************/
+
+	.note {
+		border-color: #52e052;
+		border-color: var(--note-border);
+		background: #e9fbe9;
+		background: var(--note-bg);
+		color: black;
+		color: var(--note-text);
+		overflow: auto;
+	}
+
+	.note::before, .note > .marker,
+	details.note > summary {
+		color: hsl(120, 70%, 30%);
+		color: var(--noteheading-text);
+	}
+	/* Add .note::before { content: "Note "; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
+		border-bottom: 1px var(--notesummary-underline) solid;
+	}
+
+/** Assertion Box *************************************************************/
+	/*  for assertions in algorithms */
+
+	.assertion {
+		border-color: #AAA;
+		border-color: var(--assertion-border);
+		background: #EEE;
+		background: var(--assertion-bg);
+		color: black;
+		color: var(--assertion-text);
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-color: var(--advisement-border);
+		border-style: none solid;
+		background: #fec;
+		background: var(--advisement-bg);
+		color: black;
+		color: var(--advisement-text);
+	}
+	strong.advisement {
+		display: block;
+		text-align: center;
+	}
+	.advisement::before, .advisement > .marker {
+		color: #b35f00;
+		color: var(--advisementheading-text);
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details {
+		display: block;
+	}
+	summary {
+		font-weight: bolder;
+	}
+
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
+	details.annoying-warning[open] {
+		background: hsla(40,100%,50%,0.95);
+		background: var(--warning-bg);
+		color: black;
+		color: var(--warning-text);
+		padding: .75em 1em;
+		border: red;
+		border: var(--warning-border);
+		border-style: solid none;
+		box-shadow: 0 2px 8px black;
+		text-align: center;
+	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
+	@media not print {
+		details.annoying-warning[open] {
+			position: fixed;
+			left: 0;
+			right: 0;
+			bottom: 2em;
+			z-index: 1000;
+		}
+	}
+
+	details.annoying-warning:not([open]) > summary {
+		text-align: center;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #def;
+		background: var(--def-bg);
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8ccbf2;
+		border-left: 0.5em solid var(--def-border);
+		color: black;
+		color: var(--def-text);
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.def {
+		/* inherits .def box styling, see above */
+		width: 100%;
+		border-spacing: 0;
+	}
+
+	table.def td,
+	table.def th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+		border-bottom: 1px solid var(--defrow-border);
+	}
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.def th {
+		font-style: italic;
+		font-weight: normal;
+		padding-left: 1em;
+		width: 3em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a def table */
+	table.def td.footnote {
+		padding-top: 0.6em;
+	}
+	table.def td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Data tables (and properly marked-up index tables) *************************/
+	/*
+		 <table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
+	*/
+
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
+	}
+
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		border: hidden;
+		width: 100%;
+	}
+	table.data caption,
+	table.index caption {
+		max-width: 50em;
+		margin: 0 auto 1em;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
+		border-width: 1px;
+		border-color: silver;
+		border-color: var(--datacell-border);
+		border-top-style: solid;
+	}
+
+	table.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
+		border-bottom: 2px solid;
+	}
+
+	table.data colgroup,
+	table.index colgroup {
+		border-left: 2px solid;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		border-top: 1px solid var(--datacell-border);
+		padding-right: 1em;
+	}
+
+	table.data th[colspan],
+	table.data td[colspan] {
+		text-align: center;
+	}
+
+	table.complex.data th,
+	table.complex.data td {
+		border: 1px solid silver;
+		border: 1px solid var(--datacell-border);
+		text-align: center;
+	}
+
+	table.data.longlastcol td:last-child,
+	table.data td.long {
+		vertical-align: baseline;
+		text-align: left;
+	}
+
+	table.data img {
+		vertical-align: middle;
+	}
+
+
+/*
+Alternate table alignment rules
+
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+Possible extra rowspan handling
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
+
+
+/** Table of Contents *********************************************************/
+
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1rem;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Reverse color scheme */
+		color: black;
+		color: var(--toclink-text);
+		border-color: #3980b5;
+		border-color: var(--toclink-underline);
+	}
+	.toc a:visited {
+		color: black;
+		color: var(--toclink-visited-text);
+		border-color: #054572;
+		border-color: var(--toclink-visited-underline);
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
+
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.1rem; /* consistent spacing */
+	}
+
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { font-weight: bold;   }
+	.toc > li li          { font-weight: normal; }
+	.toc > li li li       { font-size:   95%;    }
+	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li .secno { font-size: 85%; }
+	.toc > li li li li li { font-size:   85%;    }
+	.toc > li li li li li .secno { font-size: 100%; }
+
+	/* @supports not (display:grid) { */
+		.toc > li             { margin: 1.5rem 0;    }
+		.toc > li li          { margin: 0.3rem 0;    }
+		.toc > li li li       { margin-left: 2rem;   }
+
+		/* Section numbers in a column of their own */
+		.toc .secno {
+			float: left;
+			width: 4rem;
+			white-space: nowrap;
+		}
+
+		.toc li {
+			clear: both;
+		}
+
+		:not(li) > .toc              { margin-left:  5rem; }
+		.toc .secno                  { margin-left: -5rem; }
+		.toc > li li li .secno       { margin-left: -7rem; }
+		.toc > li li li li .secno    { margin-left: -9rem; }
+		.toc > li li li li li .secno { margin-left: -11rem; }
+
+		/* Tighten up indentation in narrow ToCs */
+		@media (max-width: 30em) {
+			:not(li) > .toc              { margin-left:  4rem; }
+			.toc .secno                  { margin-left: -4rem; }
+			.toc > li li li              { margin-left:  1rem; }
+			.toc > li li li .secno       { margin-left: -5rem; }
+			.toc > li li li li .secno    { margin-left: -6rem; }
+			.toc > li li li li li .secno { margin-left: -7rem; }
+		}
+		/* Loosen it on wide screens */
+		@media screen and (min-width: 78em) {
+			body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+			body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+			body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+			body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+			body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+			body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	/* } */
+
+	@supports (display:grid) and (display:contents) {
+		/* Use #toc over .toc to override non-@supports rules. */
+		#toc {
+			display: grid;
+			align-content: start;
+			grid-template-columns: auto 1fr;
+			grid-column-gap: 1rem;
+			column-gap: 1rem;
+			grid-row-gap: .6rem;
+			row-gap: .6rem;
+		}
+		#toc h2 {
+			grid-column: 1 / -1;
+			margin-bottom: 0;
+		}
+		#toc ol,
+		#toc li,
+		#toc a {
+			display: contents;
+			/* Switch <a> to subgrid when supported */
+		}
+		#toc span {
+			margin: 0;
+		}
+		#toc > .toc > li > a > span {
+			/* The spans of the top-level list,
+			   comprising the first items of each top-level section. */
+			margin-top: 1.1rem;
+		}
+		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
+			grid-column: 1;
+			width: auto;
+			margin-left: 0;
+		}
+		#toc .content {
+			grid-column: 2;
+			width: auto;
+			margin-right: 1rem;
+		}
+		#toc .content:hover,
+		#toc .content:focus {
+			background: rgba(75%, 75%, 75%, .25);
+			background: var(--a-hover-bg);
+			border-bottom: 3px solid #054572;
+			border-bottom: 3px solid var(--toclink-underline);
+			margin-bottom: -3px;
+		}
+		#toc li li li .content {
+			margin-left: 1rem;
+		}
+		#toc li li li li .content {
+			margin-left: 2rem;
+		}
+	}
+
+
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span:not(.dfn-paneled) {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: #707070;
+			color: var(--indexinfo-text);
+		}
+	}
+
+/** Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.index {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.index td,
+	table.index th {
+		padding: 0.4em;
+	}
+
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		color: black;
+		color: var(--indextable-hover-text);
+		background: #f7f8f9;
+		background: var(--indextable-hover-bg);
+	}
+
+	/* The link in the first column in the property table (formerly a TD) */
+	table.index th:first-child a {
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		/* Pages have their own margins. */
+		html {
+			margin: 0;
+		}
+		/* Serif for print. */
+		body {
+			font-family: serif;
+		}
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+
+
+
+/******************************************************************************/
+/*                             Overflow Control                               */
+/******************************************************************************/
+
+	.figure .caption, .sidefigure .caption, figcaption {
+		/* in case figure is overlarge, limit caption to 50em */
+		max-width: 50rem;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.overlarge {
+		/* Magic to create good table positioning:
+		   "content column" is 50ems wide at max; less on smaller screens.
+		   Extra space (after ToC + content) is empty on the right.
+
+		   1. When table < content column, centers table in column.
+		   2. When content < table < available, left-aligns.
+		   3. When table > available, fills available + scroll bar.
+		*/
+		display: grid;
+		grid-template-columns: minmax(0, 50em);
+	}
+	.overlarge > table {
+		/* limit preferred width of table */
+		max-width: 50em;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media (min-width: 55em) {
+		.overlarge {
+			margin-right: calc(13px + 26.5rem - 50vw);
+			max-width: none;
+		}
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) .overlarge {
+			/* 30.5em body padding 50em content area */
+			margin-right: calc(40em - 50vw) !important;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) .overlarge {
+			/* 4em html margin 30.5em body padding 50em content area */
+			margin-right: calc(84.5em - 100vw) !important;
+		}
+	}
+
+	@media not print {
+		.overlarge {
+			overflow-x: auto;
+			/* See Lea Verou's explanation background-attachment:
+			 * http://lea.verou.me/2012/04/background-attachment-local/
+			 *
+			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
+			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            white;
+			background-repeat: no-repeat;
+			*/
+		}
+	}
+</style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version b9f8371cc, updated Fri Mar 5 18:35:23 2021 -0800" name="generator">
+  <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://wicg.github.io/background-sync/spec/" rel="canonical">
-  <meta content="db1d49e6531dc200419e569b1bef130e3369318b" name="document-revision">
+  <meta content="090bad267b31b9c213013d4a84f0e4f5e7b771fa" name="document-revision">
+<style>/* darkmode */
+
+            @media (prefers-color-scheme: dark) {
+                html { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E") !important; }
+            }
+            </style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -72,13 +1396,17 @@ pre .property::before, pre .property::after {
 <style>/* style-colors */
 
 /* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+html {
+    color: black;
+    color: var(--text);
+    background-color: white;
+    background-color: var(--bg);
+}
 :root {
     color-scheme: light dark;
 
     --text: black;
     --bg: white;
-
-    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
 
     --logo-bg: #1a5e9a;
     --logo-active-bg: #c00;
@@ -152,11 +1480,6 @@ pre .property::before, pre .property::after {
     --warning-border: red;
     --warning-bg: hsla(40,100%,50%,0.95);
     --warning-text: var(--text);
-
-    --amendment-border: #330099;
-    --amendment-bg: #F5F0FF;
-    --amendment-text: var(--text);
-    --amendmentheading-text: #220066;
 
     --def-border: #8ccbf2;
     --def-bg: #def;
@@ -375,7 +1698,7 @@ dfn > a.self-link::before      { content: "#"; }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
 
-.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+.highlight:not(.idl) { background: #fdf6e3; }
 c-[a] { color: #990055 } /* Keyword.Declaration */
 c-[b] { color: #990055 } /* Keyword.Type */
 c-[c] { color: #708090 } /* Comment */
@@ -435,8 +1758,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     :root {
         --text: #ddd;
         --bg: black;
-
-        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
 
         --logo-bg: #1a5e9a;
         --logo-active-bg: #c00;
@@ -512,11 +1833,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
         --warning-border: red;
         --warning-bg: hsla(40,100%,20%,0.95);
         --warning-text: var(--text);
-
-        --amendment-border: #330099;
-        --amendment-bg: #080010;
-        --amendment-text: var(--text);
-        --amendmentheading-text: #cc00ff;
 
         --def-border: #8ccbf2;
         --def-bg: #080818;
@@ -621,9 +1937,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Background Synchronization</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-03-08">8 March 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-11-10">10 November 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -662,26 +1978,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
     <li><a href="#concepts"><span class="secno">2</span> <span class="content">Concepts</span></a>
     <li><a href="#constructs"><span class="secno">3</span> <span class="content">Constructs</span></a>
+    <li><a href="#permissions-integration"><span class="secno">4</span> <span class="content">Permissions Integration</span></a>
     <li>
-     <a href="#privacy-considerations"><span class="secno">4</span> <span class="content">Privacy Considerations</span></a>
+     <a href="#privacy-considerations"><span class="secno">5</span> <span class="content">Privacy Considerations</span></a>
      <ol class="toc">
-      <li><a href="#permission"><span class="secno">4.1</span> <span class="content">Permission</span></a>
-      <li><a href="#location-tracking"><span class="secno">4.2</span> <span class="content">Location Tracking</span></a>
-      <li><a href="#history-leaking"><span class="secno">4.3</span> <span class="content">History Leaking</span></a>
+      <li><a href="#permission"><span class="secno">5.1</span> <span class="content">Permission</span></a>
+      <li><a href="#location-tracking"><span class="secno">5.2</span> <span class="content">Location Tracking</span></a>
+      <li><a href="#history-leaking"><span class="secno">5.3</span> <span class="content">History Leaking</span></a>
      </ol>
     <li>
-     <a href="#api-description"><span class="secno">5</span> <span class="content">API Description</span></a>
+     <a href="#api-description"><span class="secno">6</span> <span class="content">API Description</span></a>
      <ol class="toc">
-      <li><a href="#service-worker-registration-extensions"><span class="secno">5.1</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerRegistration</span></code> interface</span></a>
-      <li><a href="#sync-manager-interface"><span class="secno">5.2</span> <span class="content"><code class="idl"><span>SyncManager</span></code> interface</span></a>
-      <li><a href="#sync-event"><span class="secno">5.3</span> <span class="content">The sync event</span></a>
+      <li><a href="#service-worker-registration-extensions"><span class="secno">6.1</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerRegistration</span></code> interface</span></a>
+      <li><a href="#sync-manager-interface"><span class="secno">6.2</span> <span class="content"><code class="idl"><span>SyncManager</span></code> interface</span></a>
+      <li><a href="#sync-event"><span class="secno">6.3</span> <span class="content">The sync event</span></a>
      </ol>
-    <li>
-     <a href="#w3c-conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
-     <ol class="toc">
-      <li><a href="#w3c-conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
-      <li><a href="#w3c-conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
-     </ol>
+    <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -761,25 +2073,45 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <p>Within one <a data-link-type="dfn" href="#list-of-sync-registrations" id="ref-for-list-of-sync-registrations">list of sync registrations</a> each <a data-link-type="dfn" href="#sync-registration" id="ref-for-sync-registration⑤">sync registration</a> MUST have a unique <a data-link-type="dfn" href="#tag" id="ref-for-tag①">tag</a>.</p>
    </section>
    <section>
-    <h2 class="heading settled" data-level="4" id="privacy-considerations"><span class="secno">4. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
+    <h2 class="heading settled" data-level="4" id="permissions-integration"><span class="secno">4. </span><span class="content">Permissions Integration</span><a class="self-link" href="#permissions-integration"></a></h2>
+     The Web Background Synchronization API is a <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-default-powerful-feature" id="ref-for-dfn-default-powerful-feature">default powerful feature</a> that is identified by the <a data-link-type="dfn" href="https://w3c.github.io/permissions/#dfn-name" id="ref-for-dfn-name">name</a> "background-sync". 
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="5" id="privacy-considerations"><span class="secno">5. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
     <section>
-     <h3 class="heading settled" data-level="4.1" id="permission"><span class="secno">4.1. </span><span class="content">Permission</span><a class="self-link" href="#permission"></a></h3>
+     <h3 class="heading settled" data-level="5.1" id="permission"><span class="secno">5.1. </span><span class="content">Permission</span><a class="self-link" href="#permission"></a></h3>
       User agents MAY offer a way for the user to disable background sync. 
      <p class="note" role="note"><span>Note:</span> Background sync SHOULD be enabled by default. Having the permission denied is considered an exceptional case.</p>
     </section>
     <section>
-     <h3 class="heading settled" data-level="4.2" id="location-tracking"><span class="secno">4.2. </span><span class="content">Location Tracking</span><a class="self-link" href="#location-tracking"></a></h3>
+     <h3 class="heading settled" data-level="5.2" id="location-tracking"><span class="secno">5.2. </span><span class="content">Location Tracking</span><a class="self-link" href="#location-tracking"></a></h3>
       Fetch requests within the onsync event while <a data-link-type="dfn" href="#in-the-background" id="ref-for-in-the-background①">in the background</a> may reveal the client’s IP address to the server after the user left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of sync events. 
     </section>
     <section>
-     <h3 class="heading settled" data-level="4.3" id="history-leaking"><span class="secno">4.3. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
+     <h3 class="heading settled" data-level="5.3" id="history-leaking"><span class="secno">5.3. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
       Fetch requests within the onsync event while <a data-link-type="dfn" href="#in-the-background" id="ref-for-in-the-background②">in the background</a> may reveal something about the client’s navigation history to passive eavesdroppers. For instance, the client might visit site https://example.com, which registers a sync event, but doesn’t fire until after the user has navigated away from the page and changed networks. Passive eavesdroppers on the new network may see the fetch requests that the onsync event makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request). 
     </section>
    </section>
    <section>
-    <h2 class="heading settled" data-level="5" id="api-description"><span class="secno">5. </span><span class="content">API Description</span><a class="self-link" href="#api-description"></a></h2>
+    <h2 class="heading settled" data-level="6" id="api-description"><span class="secno">6. </span><span class="content">API Description</span><a class="self-link" href="#api-description"></a></h2>
     <section>
-     <h3 class="heading settled" data-level="5.1" id="service-worker-registration-extensions"><span class="secno">5.1. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface" id="ref-for-service-worker-registration-interface">ServiceWorkerRegistration</a></code> interface</span><a class="self-link" href="#service-worker-registration-extensions"></a></h3>
+     <h3 class="heading settled" data-level="6.1" id="service-worker-registration-extensions"><span class="secno">6.1. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface" id="ref-for-service-worker-registration-interface">ServiceWorkerRegistration</a></code> interface</span><a class="self-link" href="#service-worker-registration-extensions"></a></h3>
+     <div class="mdn-anno wrapped">
+      <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+      <div class="feature">
+       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/sync" title="The sync property of the ServiceWorkerRegistration interface returns a reference to the SyncManager interface, which manages background synchronization processes.">ServiceWorkerRegistration/sync</a></p>
+       <p class="less-than-two-engines-text">In only one current engine.</p>
+       <div class="support">
+        <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+        <hr>
+        <span class="opera yes"><span>Opera</span><span>36+</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
+        <hr>
+        <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+        <hr>
+        <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android yes"><span>Android WebView</span><span>49+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>4.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>36+</span></span>
+       </div>
+      </div>
+     </div>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface" id="ref-for-service-worker-registration-interface①"><c- g>ServiceWorkerRegistration</c-></a> {
   <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#syncmanager" id="ref-for-syncmanager"><c- n>SyncManager</c-></a> <dfn class="idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export data-readonly data-type="SyncManager" id="dom-serviceworkerregistration-sync"><code><c- g>sync</c-></code><a class="self-link" href="#dom-serviceworkerregistration-sync"></a></dfn>;
 };
@@ -787,7 +2119,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p>The <code><dfn class="idl-code" data-dfn-for="SyncManager" data-dfn-type="attribute" data-export id="dom-syncmanager-sync" title="sync"><code>sync</code><a class="self-link" href="#dom-syncmanager-sync"></a></dfn></code> attribute exposes a <code class="idl"><a data-link-type="idl" href="#syncmanager" id="ref-for-syncmanager①">SyncManager</a></code>, which has an associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept" id="ref-for-service-worker-registration-concept②">service worker registration</a> represented by the <code class="idl"><a data-link-type="idl" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface" id="ref-for-service-worker-registration-interface②">ServiceWorkerRegistration</a></code> on which the attribute is exposed.</p>
     </section>
     <section>
-     <h3 class="heading settled" data-level="5.2" id="sync-manager-interface"><span class="secno">5.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#syncmanager" id="ref-for-syncmanager②">SyncManager</a></code> interface</span><a class="self-link" href="#sync-manager-interface"></a></h3>
+     <h3 class="heading settled" data-level="6.2" id="sync-manager-interface"><span class="secno">6.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#syncmanager" id="ref-for-syncmanager②">SyncManager</a></code> interface</span><a class="self-link" href="#sync-manager-interface"></a></h3>
      <div class="mdn-anno wrapped after">
       <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
       <div class="feature">
@@ -804,12 +2136,28 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        </div>
       </div>
      </div>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="syncmanager"><code><c- g>SyncManager</c-></code></dfn> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-register" id="ref-for-dom-syncmanager-register"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SyncManager/register(tag)" data-dfn-type="argument" data-export id="dom-syncmanager-register-tag-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-syncmanager-register-tag-tag"></a></dfn>);
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence" id="ref-for-idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-gettags" id="ref-for-dom-syncmanager-gettags"><c- g>getTags</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-register" id="ref-for-dom-syncmanager-register"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SyncManager/register(tag)" data-dfn-type="argument" data-export id="dom-syncmanager-register-tag-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-syncmanager-register-tag-tag"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-gettags" id="ref-for-dom-syncmanager-gettags"><c- g>getTags</c-></a>();
 };
 </pre>
+     <div class="mdn-anno wrapped">
+      <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+      <div class="feature">
+       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncManager/register" title="The SyncManager.register method of the SyncManager interface returns a Promise that resolves to a SyncRegistration instance.">SyncManager/register</a></p>
+       <p class="less-than-two-engines-text">In only one current engine.</p>
+       <div class="support">
+        <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+        <hr>
+        <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
+        <hr>
+        <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+        <hr>
+        <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android yes"><span>Android WebView</span><span>49+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+       </div>
+      </div>
+     </div>
      <p>The <code><dfn class="dfn-paneled idl-code" data-dfn-for="SyncManager" data-dfn-type="method" data-export id="dom-syncmanager-register" title="register(tag)"><code>register(<var>tag</var>)</code></dfn></code> method, when invoked, MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise" id="ref-for-a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
      <ol>
       <li> Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#syncmanager" id="ref-for-syncmanager③">SyncManager</a></code>'s associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept" id="ref-for-service-worker-registration-concept③">service worker registration</a>. 
@@ -842,6 +2190,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li> If the user agent is currently <a data-link-type="dfn" href="#online" id="ref-for-online②">online</a>, <a data-link-type="dfn" href="#fire-a-sync-event" id="ref-for-fire-a-sync-event①">fire a sync event</a> for <var>newRegistration</var>. 
        </ol>
      </ol>
+     <div class="mdn-anno wrapped">
+      <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+      <div class="feature">
+       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncManager/getTags" title="The SyncManager.getTags method of the SyncManager interface returns a list of developer-defined identifiers for SyncManager registrations.">SyncManager/getTags</a></p>
+       <p class="less-than-two-engines-text">In only one current engine.</p>
+       <div class="support">
+        <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+        <hr>
+        <span class="opera no"><span>Opera</span><span>None</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
+        <hr>
+        <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+        <hr>
+        <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android yes"><span>Android WebView</span><span>49+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>None</span></span>
+       </div>
+      </div>
+     </div>
      <p>The <code><dfn class="dfn-paneled idl-code" data-dfn-for="SyncManager" data-dfn-type="method" data-export id="dom-syncmanager-gettags" title="getTags()"><code>getTags()</code></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise" id="ref-for-a-new-promise①">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
      <ol>
       <li> Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#syncmanager" id="ref-for-syncmanager④">SyncManager</a></code>'s associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept" id="ref-for-service-worker-registration-concept⑤">service worker registration</a>. 
@@ -851,33 +2215,20 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="5.3" id="sync-event"><span class="secno">5.3. </span><span class="content">The sync event</span><a class="self-link" href="#sync-event"></a></h3>
+     <h3 class="heading settled" data-level="6.3" id="sync-event"><span class="secno">6.3. </span><span class="content">The sync event</span><a class="self-link" href="#sync-event"></a></h3>
      <div class="mdn-anno wrapped after">
       <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
       <div class="feature">
-       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent/lastChance" title="The SyncEvent.lastChance read-only property of the SyncEvent interface returns true if the user agent will not make further synchronization attempts after the current attempt. This is the value passed in the lastChance parameter of the SyncEvent() constructor.">SyncEvent/lastChance</a></p>
+       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent" title="The SyncEvent interface represents a sync action that is dispatched on the ServiceWorkerGlobalScope of a ServiceWorker.">SyncEvent</a></p>
        <p class="less-than-two-engines-text">In only one current engine.</p>
        <div class="support">
-        <span class="firefox no"><span>Firefox</span><span>?</span></span><span class="safari no"><span>Safari</span><span>?</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+        <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
         <hr>
         <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
         <hr>
         <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
         <hr>
-        <span class="firefox_android no"><span>Firefox for Android</span><span>?</span></span><span class="safari_ios no"><span>iOS Safari</span><span>?</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
-       </div>
-      </div>
-      <div class="feature">
-       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent/tag" title="The SyncEvent.tag read-only property of the SyncEvent interface returns the developer-defined identifier for this SyncEvent. This is the value passed in the tag parameter of the SyncEvent() constructor.">SyncEvent/tag</a></p>
-       <p class="less-than-two-engines-text">In only one current engine.</p>
-       <div class="support">
-        <span class="firefox no"><span>Firefox</span><span>?</span></span><span class="safari no"><span>Safari</span><span>?</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
-        <hr>
-        <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
-        <hr>
-        <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
-        <hr>
-        <span class="firefox_android no"><span>Firefox for Android</span><span>?</span></span><span class="safari_ios no"><span>iOS Safari</span><span>?</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
+        <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
        </div>
       </div>
      </div>
@@ -896,21 +2247,34 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <span class="firefox_android yes"><span>Firefox for Android</span><span>44+</span></span><span class="safari_ios yes"><span>iOS Safari</span><span>11.3+</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android yes"><span>Android WebView</span><span>49+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>24+</span></span>
        </div>
       </div>
+      <div class="feature">
+       <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent/SyncEvent" title="The SyncEvent() constructor creates a new SyncEvent object.">SyncEvent/SyncEvent</a></p>
+       <p class="less-than-two-engines-text">In only one current engine.</p>
+       <div class="support">
+        <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+        <hr>
+        <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
+        <hr>
+        <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+        <hr>
+        <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
+       </div>
+      </div>
      </div>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface"><c- g>ServiceWorkerGlobalScope</c-></a> {
   <c- b>attribute</c-> <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler" id="ref-for-eventhandler"><c- n>EventHandler</c-></a> <dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export data-type="EventHandler" id="dom-serviceworkerglobalscope-onsync"><code><c- g>onsync</c-></code><a class="self-link" href="#dom-serviceworkerglobalscope-onsync"></a></dfn>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="syncevent"><code><c- g>SyncEvent</c-></code></dfn> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface" id="ref-for-extendable-event-interface"><c- n>ExtendableEvent</c-></a> {
   <dfn class="idl-code" data-dfn-for="SyncEvent" data-dfn-type="constructor" data-export data-lt="SyncEvent(type, init)|constructor(type, init)" id="dom-syncevent-syncevent"><code><c- g>constructor</c-></code><a class="self-link" href="#dom-syncevent-syncevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SyncEvent/SyncEvent(type, init), SyncEvent/constructor(type, init)" data-dfn-type="argument" data-export id="dom-syncevent-syncevent-type-init-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-syncevent-syncevent-type-init-type"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-synceventinit" id="ref-for-dictdef-synceventinit"><c- n>SyncEventInit</c-></a> <dfn class="idl-code" data-dfn-for="SyncEvent/SyncEvent(type, init), SyncEvent/constructor(type, init)" data-dfn-type="argument" data-export id="dom-syncevent-syncevent-type-init-init"><code><c- g>init</c-></code><a class="self-link" href="#dom-syncevent-syncevent-type-init-init"></a></dfn>);
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SyncEvent" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-syncevent-tag"><code><c- g>tag</c-></code></dfn>;
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SyncEvent" data-dfn-type="attribute" data-export data-readonly data-type="boolean" id="dom-syncevent-lastchance"><code><c- g>lastChance</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SyncEvent" data-dfn-type="attribute" data-export data-readonly data-type="boolean" id="dom-syncevent-lastchance"><code><c- g>lastChance</c-></code></dfn>;
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-synceventinit"><code><c- g>SyncEventInit</c-></code></dfn> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary" id="ref-for-extendable-event-init-dictionary"><c- n>ExtendableEventInit</c-></a> {
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="SyncEventInit" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-synceventinit-tag"><code><c- g>tag</c-></code><a class="self-link" href="#dom-synceventinit-tag"></a></dfn>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="idl-code" data-default="false" data-dfn-for="SyncEventInit" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-synceventinit-lastchance"><code><c- g>lastChance</c-></code><a class="self-link" href="#dom-synceventinit-lastchance"></a></dfn> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="idl-code" data-default="false" data-dfn-for="SyncEventInit" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-synceventinit-lastchance"><code><c- g>lastChance</c-></code><a class="self-link" href="#dom-synceventinit-lastchance"></a></dfn> = <c- b>false</c->;
 };
 </pre>
      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#syncevent" id="ref-for-syncevent">SyncEvent</a></code> interface represents a firing sync registration. If the page (or worker) that registered the event is running, the user agent will fire the sync event as soon as network connectivity is available. Otherwise, the user agent should run the event at the soonest convenience. If a sync event fails, the user agent may decide to retry it at a time of its choosing. The <code class="idl"><a data-link-type="idl" href="#dom-syncevent-lastchance" id="ref-for-dom-syncevent-lastchance">lastChance</a></code> attribute is true if the user agent will not make further attempts to try this sync after the current attempt.</p>
@@ -942,9 +2306,43 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        <p><a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#fire-functional-event" id="ref-for-fire-functional-event">Fire Functional Event</a> "<code>sync</code>" using <code class="idl"><a data-link-type="idl" href="#syncevent" id="ref-for-syncevent①">SyncEvent</a></code> on <var>serviceWorkerRegistration</var> with the following properties:</p>
        <dl>
-        <dt><code class="idl"><a data-link-type="idl" href="#dom-syncevent-tag" id="ref-for-dom-syncevent-tag">tag</a></code>
+        <dt>
+         <div class="mdn-anno wrapped">
+          <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+          <div class="feature">
+           <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent/tag" title="The SyncEvent.tag read-only property of the SyncEvent interface returns the developer-defined identifier for this SyncEvent. This is the value passed in the tag parameter of the SyncEvent() constructor.">SyncEvent/tag</a></p>
+           <p class="less-than-two-engines-text">In only one current engine.</p>
+           <div class="support">
+            <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+            <hr>
+            <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
+            <hr>
+            <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+            <hr>
+            <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
+           </div>
+          </div>
+         </div>
+         <code class="idl"><a data-link-type="idl" href="#dom-syncevent-tag" id="ref-for-dom-syncevent-tag">tag</a></code>
         <dd>The <a data-link-type="dfn" href="#tag" id="ref-for-tag⑤">tag</a> associated with <var>registration</var>
-        <dt><code class="idl"><a data-link-type="idl" href="#dom-syncevent-lastchance" id="ref-for-dom-syncevent-lastchance③">lastChance</a></code>
+        <dt>
+         <div class="mdn-anno wrapped">
+          <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+          <div class="feature">
+           <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent/lastChance" title="The SyncEvent.lastChance read-only property of the SyncEvent interface returns true if the user agent will not make further synchronization attempts after the current attempt. This is the value passed in the lastChance parameter of the SyncEvent() constructor.">SyncEvent/lastChance</a></p>
+           <p class="less-than-two-engines-text">In only one current engine.</p>
+           <div class="support">
+            <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>49+</span></span>
+            <hr>
+            <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>79+</span></span>
+            <hr>
+            <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+            <hr>
+            <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>49+</span></span><span class="webview_android no"><span>Android WebView</span><span>None</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>5.0+</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
+           </div>
+          </div>
+         </div>
+         <code class="idl"><a data-link-type="idl" href="#dom-syncevent-lastchance" id="ref-for-dom-syncevent-lastchance③">lastChance</a></code>
         <dd>False if the user agent <a data-link-type="dfn" href="#will-retry" id="ref-for-will-retry">will retry</a> this sync event if it fails, or true if no further attempts will be made after the current attempt.
        </dl>
        <p>Then run the following steps with <var>dispatchedEvent</var>:</p>
@@ -991,99 +2389,203 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    </section>
   </main>
   <div data-fill-with="conformance">
-   <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
-   <h3 class="no-ref no-num heading settled" id="w3c-conventions"><span class="content">Document conventions</span><a class="self-link" href="#w3c-conventions"></a></h3>
-   <p>Conformance requirements are expressed
-    with a combination of descriptive assertions
-    and RFC 2119 terminology.
-    The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
-    in the normative parts of this document
-    are to be interpreted as described in RFC 2119.
-    However, for readability,
-    these words do not appear in all uppercase letters in this specification. </p>
-   <p>All of the text of this specification is normative
-    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
-   <p>Examples in this specification are introduced with the words “for example”
-    or are set apart from the normative text
-    with <code>class="example"</code>,
-    like this: </p>
-   <div class="example" id="w3c-example">
-    <a class="self-link" href="#w3c-example"></a> 
-    <p>This is an example of an informative example. </p>
-   </div>
-   <p>Informative notes begin with the word “Note”
-    and are set apart from the normative text
-    with <code>class="note"</code>,
-    like this: </p>
-   <p class="note" role="note">Note, this is an informative note. </p>
-   <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
-   <p>Requirements phrased in the imperative as part of algorithms
-    (such as "strip any leading space characters"
-    or "return false and abort these steps")
-    are to be interpreted with the meaning of the key word
-    ("must", "should", "may", etc)
-    used in introducing the algorithm. </p>
-   <p>Conformance requirements phrased as algorithms or specific steps
-    can be implemented in any manner,
-    so long as the end result is equivalent.
-    In particular, the algorithms defined in this specification
-    are intended to be easy to understand
-    and are not intended to be performant.
-    Implementers are encouraged to optimize. </p>
+   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <p> Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+            The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+            in the normative parts of this document
+            are to be interpreted as described in RFC 2119.
+            However, for readability,
+            these words do not appear in all uppercase letters in this specification. </p>
+   <p> All of the text of this specification is normative
+            except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+   <p> Examples in this specification are introduced with the words “for example”
+            or are set apart from the normative text with <code>class="example"</code>, like this: </p>
+   <div class="example" id="example-example"><a class="self-link" href="#example-example"></a> This is an example of an informative example. </div>
+   <p> Informative notes begin with the word “Note”
+            and are set apart from the normative text with <code>class="note"</code>, like this: </p>
+   <p class="note" role="note"> Note, this is an informative note. </p>
   </div>
-<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+<script>
+(function() {
+  "use strict";
+  var collapseSidebarText = '<span aria-hidden="true">←</span> '
+                          + '<span>Collapse Sidebar</span>';
+  var expandSidebarText   = '<span aria-hidden="true">→</span> '
+                          + '<span>Pop Out Sidebar</span>';
+  var tocJumpText         = '<span aria-hidden="true">↑</span> '
+                          + '<span>Jump to Table of Contents</span>';
+
+  var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
+  var autoToggle   = function(e){ toggleSidebar(e.matches) };
+  if(sidebarMedia.addListener) {
+    sidebarMedia.addListener(autoToggle);
+  }
+
+  function toggleSidebar(on) {
+    if (on == undefined) {
+      on = !document.body.classList.contains('toc-sidebar');
+    }
+
+    /* Don’t scroll to compensate for the ToC if we’re above it already. */
+    var headY = 0;
+    var head = document.querySelector('.head');
+    if (head) {
+      // terrible approx of "top of ToC"
+      headY += head.offsetTop + head.offsetHeight;
+    }
+    var skipScroll = window.scrollY < headY;
+
+    var toggle = document.getElementById('toc-toggle');
+    var tocNav = document.getElementById('toc');
+    if (on) {
+      var tocHeight = tocNav.offsetHeight;
+      document.body.classList.add('toc-sidebar');
+      document.body.classList.remove('toc-inline');
+      toggle.innerHTML = collapseSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, 0 - tocHeight);
+      }
+      tocNav.focus();
+      sidebarMedia.addListener(autoToggle); // auto-collapse when out of room
+    }
+    else {
+      document.body.classList.add('toc-inline');
+      document.body.classList.remove('toc-sidebar');
+      toggle.innerHTML = expandSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, tocNav.offsetHeight);
+      }
+      if (toggle.matches(':hover')) {
+        /* Unfocus button when not using keyboard navigation,
+           because I don’t know where else to send the focus. */
+        toggle.blur();
+      }
+    }
+  }
+
+  function createSidebarToggle() {
+    /* Create the sidebar toggle in JS; it shouldn’t exist when JS is off. */
+    var toggle = document.createElement('a');
+      /* This should probably be a button, but appearance isn’t standards-track.*/
+    toggle.id = 'toc-toggle';
+    toggle.class = 'toc-toggle';
+    toggle.href = '#toc';
+    toggle.innerHTML = collapseSidebarText;
+
+    sidebarMedia.addListener(autoToggle);
+    var toggler = function(e) {
+      e.preventDefault();
+      sidebarMedia.removeListener(autoToggle); // persist explicit off states
+      toggleSidebar();
+      return false;
+    }
+    toggle.addEventListener('click', toggler, false);
+
+
+    /* Get <nav id=toc-nav>, or make it if we don’t have one. */
+    var tocNav = document.getElementById('toc-nav');
+    if (!tocNav) {
+      tocNav = document.createElement('p');
+      tocNav.id = 'toc-nav';
+      /* Prepend for better keyboard navigation */
+      document.body.insertBefore(tocNav, document.body.firstChild);
+    }
+    /* While we’re at it, make sure we have a Jump to Toc link. */
+    var tocJump = document.getElementById('toc-jump');
+    if (!tocJump) {
+      tocJump = document.createElement('a');
+      tocJump.id = 'toc-jump';
+      tocJump.href = '#toc';
+      tocJump.innerHTML = tocJumpText;
+      tocNav.appendChild(tocJump);
+    }
+
+    tocNav.appendChild(toggle);
+  }
+
+  var toc = document.getElementById('toc');
+  if (toc) {
+    createSidebarToggle();
+    toggleSidebar(sidebarMedia.matches);
+
+    /* If the sidebar has been manually opened and is currently overlaying the text
+       (window too small for the MQ to add the margin to body),
+       then auto-close the sidebar once you click on something in there. */
+    toc.addEventListener('click', function(e) {
+      if(e.target.tagName.toLowerCase() == "a" && document.body.classList.contains('toc-sidebar') && !sidebarMedia.matches) {
+        toggleSidebar(false);
+      }
+    }, false);
+  }
+  else {
+    console.warn("Can’t find Table of Contents. Please use <nav id='toc'> around the ToC.");
+  }
+
+  /* Wrap tables in case they overflow */
+  var tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
+  var numTables = tables.length;
+  for (var i = 0; i < numTables; i++) {
+    var table = tables[i];
+    var wrapper = document.createElement('div');
+    wrapper.className = 'overlarge';
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  }
+
+})();
+</script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-syncevent-syncevent">constructor(type, init)</a><span>, in §5.3</span>
-   <li><a href="#fire-a-sync-event">fire a sync event</a><span>, in §5.3</span>
+   <li><a href="#dom-syncevent-syncevent">constructor(type, init)</a><span>, in §6.3</span>
+   <li><a href="#fire-a-sync-event">fire a sync event</a><span>, in §6.3</span>
    <li><a href="#firing">firing</a><span>, in §3</span>
-   <li><a href="#dom-syncmanager-gettags">getTags()</a><span>, in §5.2</span>
+   <li><a href="#dom-syncmanager-gettags">getTags()</a><span>, in §6.2</span>
    <li><a href="#in-the-background">in the background</a><span>, in §2</span>
    <li>
     lastChance
     <ul>
-     <li><a href="#dom-syncevent-lastchance">attribute for SyncEvent</a><span>, in §5.3</span>
-     <li><a href="#dom-synceventinit-lastchance">dict-member for SyncEventInit</a><span>, in §5.3</span>
+     <li><a href="#dom-syncevent-lastchance">attribute for SyncEvent</a><span>, in §6.3</span>
+     <li><a href="#dom-synceventinit-lastchance">dict-member for SyncEventInit</a><span>, in §6.3</span>
     </ul>
    <li><a href="#list-of-sync-registrations">list of sync registrations</a><span>, in §3</span>
    <li><a href="#online">online</a><span>, in §2</span>
-   <li><a href="#dom-serviceworkerglobalscope-onsync">onsync</a><span>, in §5.3</span>
+   <li><a href="#dom-serviceworkerglobalscope-onsync">onsync</a><span>, in §6.3</span>
    <li><a href="#pending">pending</a><span>, in §3</span>
-   <li><a href="#dom-syncmanager-register">register(tag)</a><span>, in §5.2</span>
+   <li><a href="#dom-syncmanager-register">register(tag)</a><span>, in §6.2</span>
    <li><a href="#registration-state">registration state</a><span>, in §3</span>
    <li><a href="#reregisteredwhilefiring">reregisteredWhileFiring</a><span>, in §3</span>
    <li>
     sync
     <ul>
-     <li><a href="#dom-serviceworkerregistration-sync">attribute for ServiceWorkerRegistration</a><span>, in §5.1</span>
-     <li><a href="#dom-syncmanager-sync">attribute for SyncManager</a><span>, in §5.1</span>
+     <li><a href="#dom-serviceworkerregistration-sync">attribute for ServiceWorkerRegistration</a><span>, in §6.1</span>
+     <li><a href="#dom-syncmanager-sync">attribute for SyncManager</a><span>, in §6.1</span>
     </ul>
-   <li><a href="#syncevent">SyncEvent</a><span>, in §5.3</span>
-   <li><a href="#dictdef-synceventinit">SyncEventInit</a><span>, in §5.3</span>
-   <li><a href="#dom-syncevent-syncevent">SyncEvent(type, init)</a><span>, in §5.3</span>
-   <li><a href="#syncmanager">SyncManager</a><span>, in §5.2</span>
+   <li><a href="#syncevent">SyncEvent</a><span>, in §6.3</span>
+   <li><a href="#dictdef-synceventinit">SyncEventInit</a><span>, in §6.3</span>
+   <li><a href="#dom-syncevent-syncevent">SyncEvent(type, init)</a><span>, in §6.3</span>
+   <li><a href="#syncmanager">SyncManager</a><span>, in §6.2</span>
    <li><a href="#sync-registration">sync registration</a><span>, in §3</span>
    <li>
     tag
     <ul>
-     <li><a href="#dom-syncevent-tag">attribute for SyncEvent</a><span>, in §5.3</span>
+     <li><a href="#dom-syncevent-tag">attribute for SyncEvent</a><span>, in §6.3</span>
      <li><a href="#tag">definition of</a><span>, in §3</span>
-     <li><a href="#dom-synceventinit-tag">dict-member for SyncEventInit</a><span>, in §5.3</span>
+     <li><a href="#dom-synceventinit-tag">dict-member for SyncEventInit</a><span>, in §6.3</span>
     </ul>
    <li><a href="#waiting">waiting</a><span>, in §3</span>
-   <li><a href="#will-retry">will retry</a><span>, in §5.3</span>
+   <li><a href="#will-retry">will retry</a><span>, in §6.3</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
    <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sec-algorithm-conventions">5.3. The sync event</a> <a href="#ref-for-sec-algorithm-conventions①">(2)</a> <a href="#ref-for-sec-algorithm-conventions②">(3)</a>
+    <li><a href="#ref-for-sec-algorithm-conventions">6.3. The sync event</a> <a href="#ref-for-sec-algorithm-conventions①">(2)</a> <a href="#ref-for-sec-algorithm-conventions②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-eventhandler">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-eventhandler">5.3. The sync event</a>
+    <li><a href="#ref-for-eventhandler">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
@@ -1095,44 +2597,56 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-in-parallel">
    <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-in-parallel">5.2. SyncManager interface</a> <a href="#ref-for-in-parallel①">(2)</a>
-    <li><a href="#ref-for-in-parallel②">5.3. The sync event</a>
+    <li><a href="#ref-for-in-parallel">6.2. SyncManager interface</a> <a href="#ref-for-in-parallel①">(2)</a>
+    <li><a href="#ref-for-in-parallel②">6.3. The sync event</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-default-powerful-feature">
+   <a href="https://w3c.github.io/permissions/#dfn-default-powerful-feature">https://w3c.github.io/permissions/#dfn-default-powerful-feature</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-default-powerful-feature">4. Permissions Integration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dfn-name">
+   <a href="https://w3c.github.io/permissions/#dfn-name">https://w3c.github.io/permissions/#dfn-name</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-name">4. Permissions Integration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-a-new-promise">
    <a href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-a-new-promise">5.2. SyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a>
+    <li><a href="#ref-for-a-new-promise">6.2. SyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-reject-promise">
    <a href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">https://www.w3.org/2001/tag/doc/promises-guide#reject-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reject-promise">5.2. SyncManager interface</a> <a href="#ref-for-reject-promise①">(2)</a> <a href="#ref-for-reject-promise②">(3)</a>
+    <li><a href="#ref-for-reject-promise">6.2. SyncManager interface</a> <a href="#ref-for-reject-promise①">(2)</a> <a href="#ref-for-reject-promise②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-resolve-promise">
    <a href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resolve-promise">5.2. SyncManager interface</a> <a href="#ref-for-resolve-promise①">(2)</a> <a href="#ref-for-resolve-promise②">(3)</a>
+    <li><a href="#ref-for-resolve-promise">6.2. SyncManager interface</a> <a href="#ref-for-resolve-promise①">(2)</a> <a href="#ref-for-resolve-promise②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
    <a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-upon-fulfillment">5.3. The sync event</a>
+    <li><a href="#ref-for-upon-fulfillment">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-upon-rejection">
    <a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection">https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-upon-rejection">5.3. The sync event</a>
+    <li><a href="#ref-for-upon-rejection">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-waiting-for-all">
    <a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-waiting-for-all">5.3. The sync event</a>
+    <li><a href="#ref-for-waiting-for-all">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-secure-context">
@@ -1144,50 +2658,50 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-extendable-event-interface">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendable-event-interface">5.3. The sync event</a> <a href="#ref-for-extendable-event-interface①">(2)</a>
+    <li><a href="#ref-for-extendable-event-interface">6.3. The sync event</a> <a href="#ref-for-extendable-event-interface①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-extendable-event-init-dictionary">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendable-event-init-dictionary">5.3. The sync event</a>
+    <li><a href="#ref-for-extendable-event-init-dictionary">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-service-worker-global-scope-interface">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-service-worker-global-scope-interface">5.3. The sync event</a>
+    <li><a href="#ref-for-service-worker-global-scope-interface">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-service-worker-registration-interface">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-service-worker-registration-interface">5.1. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-service-worker-registration-interface①">(2)</a> <a href="#ref-for-service-worker-registration-interface②">(3)</a>
+    <li><a href="#ref-for-service-worker-registration-interface">6.1. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-service-worker-registration-interface①">(2)</a> <a href="#ref-for-service-worker-registration-interface②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-active-worker">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-dfn-active-worker">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-extend-lifetime-promises">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-extend-lifetime-promises">5.3. The sync event</a>
+    <li><a href="#ref-for-dfn-extend-lifetime-promises">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-fire-functional-event">
    <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fire-functional-event">5.3. The sync event</a>
+    <li><a href="#ref-for-fire-functional-event">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">2. Concepts</a>
-    <li><a href="#ref-for-dfn-service-worker-client-frame-type①">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-dfn-service-worker-client-frame-type①">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-service-worker-concept">
@@ -1195,85 +2709,85 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-service-worker-concept">1. Introduction</a> <a href="#ref-for-service-worker-concept①">(2)</a>
     <li><a href="#ref-for-service-worker-concept②">2. Concepts</a>
-    <li><a href="#ref-for-service-worker-concept③">5.3. The sync event</a>
+    <li><a href="#ref-for-service-worker-concept③">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2. Concepts</a>
-    <li><a href="#ref-for-dfn-service-worker-client①">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-dfn-service-worker-client①">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-service-worker-registration-concept">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-concept">3. Constructs</a> <a href="#ref-for-service-worker-registration-concept①">(2)</a>
-    <li><a href="#ref-for-service-worker-registration-concept②">5.1. Extensions to the ServiceWorkerRegistration interface</a>
-    <li><a href="#ref-for-service-worker-registration-concept③">5.2. SyncManager interface</a> <a href="#ref-for-service-worker-registration-concept④">(2)</a> <a href="#ref-for-service-worker-registration-concept⑤">(3)</a>
-    <li><a href="#ref-for-service-worker-registration-concept⑥">5.3. The sync event</a>
+    <li><a href="#ref-for-service-worker-registration-concept②">6.1. Extensions to the ServiceWorkerRegistration interface</a>
+    <li><a href="#ref-for-service-worker-registration-concept③">6.2. SyncManager interface</a> <a href="#ref-for-service-worker-registration-concept④">(2)</a> <a href="#ref-for-service-worker-registration-concept⑤">(3)</a>
+    <li><a href="#ref-for-service-worker-registration-concept⑥">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-terminate-service-worker-algorithm">
    <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-terminate-service-worker-algorithm">5.3. The sync event</a>
+    <li><a href="#ref-for-terminate-service-worker-algorithm">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
    <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMString">5.2. SyncManager interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
-    <li><a href="#ref-for-idl-DOMString②">5.3. The sync event</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a>
+    <li><a href="#ref-for-idl-DOMString">6.2. SyncManager interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
+    <li><a href="#ref-for-idl-DOMString②">6.3. The sync event</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Exposed">5.2. SyncManager interface</a>
-    <li><a href="#ref-for-Exposed①">5.3. The sync event</a>
+    <li><a href="#ref-for-Exposed">6.2. SyncManager interface</a>
+    <li><a href="#ref-for-Exposed①">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
    <a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidaccesserror">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-invalidaccesserror">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-invalidstateerror">
    <a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-invalidstateerror">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-invalidstateerror">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-notallowederror">
    <a href="https://heycam.github.io/webidl/#notallowederror">https://heycam.github.io/webidl/#notallowederror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-notallowederror">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-notallowederror">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://heycam.github.io/webidl/#idl-promise">https://heycam.github.io/webidl/#idl-promise</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-promise">5.2. SyncManager interface</a> <a href="#ref-for-idl-promise①">(2)</a>
+    <li><a href="#ref-for-idl-promise">6.2. SyncManager interface</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-boolean">5.3. The sync event</a> <a href="#ref-for-idl-boolean①">(2)</a>
+    <li><a href="#ref-for-idl-boolean">6.3. The sync event</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-sequence">
    <a href="https://heycam.github.io/webidl/#idl-sequence">https://heycam.github.io/webidl/#idl-sequence</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-sequence">5.2. SyncManager interface</a> <a href="#ref-for-idl-sequence①">(2)</a>
+    <li><a href="#ref-for-idl-sequence①">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://heycam.github.io/webidl/#idl-undefined">https://heycam.github.io/webidl/#idl-undefined</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-undefined">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-idl-undefined">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -1289,6 +2803,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li><span class="dfn-paneled" id="term-for-eventhandler">EventHandler</span>
      <li><span class="dfn-paneled" id="term-for-browsing-context">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-in-parallel">in parallel</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[permissions]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dfn-default-powerful-feature">default powerful feature</span>
+     <li><span class="dfn-paneled" id="term-for-dfn-name">name</span>
     </ul>
    <li>
     <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
@@ -1322,7 +2842,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li><span class="dfn-paneled" id="term-for-terminate-service-worker-algorithm">termination</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
      <li><span class="dfn-paneled" id="term-for-Exposed">Exposed</span>
@@ -1339,45 +2859,47 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
-   <dd><a href="https://tc39.es/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a>
+   <dd><a href="https://tc39.es/ecma262/multipage/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.es/ecma262/multipage/">https://tc39.es/ecma262/multipage/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-permissions">[PERMISSIONS]
+   <dd>Marcos Caceres; Mike Taylor; Jeffrey Yasskin. <a href="https://www.w3.org/TR/permissions/">Permissions</a>. 23 October 2021. WD. URL: <a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
    <dt id="biblio-promises-guide">[PROMISES-GUIDE]
    <dd><a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 24 July 2015. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
-   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
+   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 18 September 2021. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-service-workers-1">[SERVICE-WORKERS-1]
    <dd>Alex Russell; et al. <a href="https://www.w3.org/TR/service-workers-1/">Service Workers 1</a>. 19 November 2019. CR. URL: <a href="https://www.w3.org/TR/service-workers-1/">https://www.w3.org/TR/service-workers-1/</a>
-   <dt id="biblio-webidl">[WebIDL]
-   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dt id="biblio-webidl">[WEBIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/">Web IDL Standard</a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface"><c- g>ServiceWorkerRegistration</c-></a> {
   <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#syncmanager"><c- n>SyncManager</c-></a> <a data-readonly data-type="SyncManager" href="#dom-serviceworkerregistration-sync"><code><c- g>sync</c-></code></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a href="#syncmanager"><code><c- g>SyncManager</c-></code></a> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-register"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-syncmanager-register-tag-tag"><code><c- g>tag</c-></code></a>);
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-gettags"><c- g>getTags</c-></a>();
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-register"><c- g>register</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-syncmanager-register-tag-tag"><code><c- g>tag</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a>>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-gettags"><c- g>getTags</c-></a>();
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface"><c- g>ServiceWorkerGlobalScope</c-></a> {
   <c- b>attribute</c-> <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler"><c- n>EventHandler</c-></a> <a data-type="EventHandler" href="#dom-serviceworkerglobalscope-onsync"><code><c- g>onsync</c-></code></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>ServiceWorker</c->]
 <c- b>interface</c-> <a href="#syncevent"><code><c- g>SyncEvent</c-></code></a> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface"><c- n>ExtendableEvent</c-></a> {
   <a href="#dom-syncevent-syncevent"><code><c- g>constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-syncevent-syncevent-type-init-type"><code><c- g>type</c-></code></a>, <a data-link-type="idl-name" href="#dictdef-synceventinit"><c- n>SyncEventInit</c-></a> <a href="#dom-syncevent-syncevent-type-init-init"><code><c- g>init</c-></code></a>);
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a data-readonly data-type="DOMString" href="#dom-syncevent-tag"><code><c- g>tag</c-></code></a>;
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-syncevent-lastchance"><code><c- g>lastChance</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-readonly data-type="boolean" href="#dom-syncevent-lastchance"><code><c- g>lastChance</c-></code></a>;
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-synceventinit"><code><c- g>SyncEventInit</c-></code></a> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary"><c- n>ExtendableEventInit</c-></a> {
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString " href="#dom-synceventinit-tag"><code><c- g>tag</c-></code></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-synceventinit-lastchance"><code><c- g>lastChance</c-></code></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-synceventinit-lastchance"><code><c- g>lastChance</c-></code></a> = <c- b>false</c->;
 };
 
 </pre>
@@ -1385,24 +2907,24 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#in-the-background">#in-the-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-the-background">1. Introduction</a>
-    <li><a href="#ref-for-in-the-background①">4.2. Location Tracking</a>
-    <li><a href="#ref-for-in-the-background②">4.3. History Leaking</a>
+    <li><a href="#ref-for-in-the-background①">5.2. Location Tracking</a>
+    <li><a href="#ref-for-in-the-background②">5.3. History Leaking</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="online">
    <b><a href="#online">#online</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-online">2. Concepts</a>
-    <li><a href="#ref-for-online①">5.2. SyncManager interface</a> <a href="#ref-for-online②">(2)</a>
-    <li><a href="#ref-for-online③">5.3. The sync event</a> <a href="#ref-for-online④">(2)</a> <a href="#ref-for-online⑤">(3)</a> <a href="#ref-for-online⑥">(4)</a>
+    <li><a href="#ref-for-online①">6.2. SyncManager interface</a> <a href="#ref-for-online②">(2)</a>
+    <li><a href="#ref-for-online③">6.3. The sync event</a> <a href="#ref-for-online④">(2)</a> <a href="#ref-for-online⑤">(3)</a> <a href="#ref-for-online⑥">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="list-of-sync-registrations">
    <b><a href="#list-of-sync-registrations">#list-of-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-sync-registrations">3. Constructs</a>
-    <li><a href="#ref-for-list-of-sync-registrations①">5.2. SyncManager interface</a> <a href="#ref-for-list-of-sync-registrations②">(2)</a> <a href="#ref-for-list-of-sync-registrations③">(3)</a>
-    <li><a href="#ref-for-list-of-sync-registrations④">5.3. The sync event</a> <a href="#ref-for-list-of-sync-registrations⑤">(2)</a> <a href="#ref-for-list-of-sync-registrations⑥">(3)</a>
+    <li><a href="#ref-for-list-of-sync-registrations①">6.2. SyncManager interface</a> <a href="#ref-for-list-of-sync-registrations②">(2)</a> <a href="#ref-for-list-of-sync-registrations③">(3)</a>
+    <li><a href="#ref-for-list-of-sync-registrations④">6.3. The sync event</a> <a href="#ref-for-list-of-sync-registrations⑤">(2)</a> <a href="#ref-for-list-of-sync-registrations⑥">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sync-registration">
@@ -1410,109 +2932,109 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-sync-registration">2. Concepts</a>
     <li><a href="#ref-for-sync-registration①">3. Constructs</a> <a href="#ref-for-sync-registration②">(2)</a> <a href="#ref-for-sync-registration③">(3)</a> <a href="#ref-for-sync-registration④">(4)</a> <a href="#ref-for-sync-registration⑤">(5)</a>
-    <li><a href="#ref-for-sync-registration⑥">5.2. SyncManager interface</a> <a href="#ref-for-sync-registration⑦">(2)</a>
-    <li><a href="#ref-for-sync-registration⑧">5.3. The sync event</a> <a href="#ref-for-sync-registration⑨">(2)</a>
+    <li><a href="#ref-for-sync-registration⑥">6.2. SyncManager interface</a> <a href="#ref-for-sync-registration⑦">(2)</a>
+    <li><a href="#ref-for-sync-registration⑧">6.3. The sync event</a> <a href="#ref-for-sync-registration⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="tag">
    <b><a href="#tag">#tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tag">3. Constructs</a> <a href="#ref-for-tag①">(2)</a>
-    <li><a href="#ref-for-tag②">5.2. SyncManager interface</a> <a href="#ref-for-tag③">(2)</a> <a href="#ref-for-tag④">(3)</a>
-    <li><a href="#ref-for-tag⑤">5.3. The sync event</a>
+    <li><a href="#ref-for-tag②">6.2. SyncManager interface</a> <a href="#ref-for-tag③">(2)</a> <a href="#ref-for-tag④">(3)</a>
+    <li><a href="#ref-for-tag⑤">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="registration-state">
    <b><a href="#registration-state">#registration-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registration-state">3. Constructs</a>
-    <li><a href="#ref-for-registration-state①">5.2. SyncManager interface</a> <a href="#ref-for-registration-state②">(2)</a> <a href="#ref-for-registration-state③">(3)</a> <a href="#ref-for-registration-state④">(4)</a> <a href="#ref-for-registration-state⑤">(5)</a>
-    <li><a href="#ref-for-registration-state⑥">5.3. The sync event</a> <a href="#ref-for-registration-state⑦">(2)</a> <a href="#ref-for-registration-state⑧">(3)</a> <a href="#ref-for-registration-state⑨">(4)</a> <a href="#ref-for-registration-state①⓪">(5)</a> <a href="#ref-for-registration-state①①">(6)</a> <a href="#ref-for-registration-state①②">(7)</a>
+    <li><a href="#ref-for-registration-state①">6.2. SyncManager interface</a> <a href="#ref-for-registration-state②">(2)</a> <a href="#ref-for-registration-state③">(3)</a> <a href="#ref-for-registration-state④">(4)</a> <a href="#ref-for-registration-state⑤">(5)</a>
+    <li><a href="#ref-for-registration-state⑥">6.3. The sync event</a> <a href="#ref-for-registration-state⑦">(2)</a> <a href="#ref-for-registration-state⑧">(3)</a> <a href="#ref-for-registration-state⑨">(4)</a> <a href="#ref-for-registration-state①⓪">(5)</a> <a href="#ref-for-registration-state①①">(6)</a> <a href="#ref-for-registration-state①②">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="pending">
    <b><a href="#pending">#pending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending">3. Constructs</a>
-    <li><a href="#ref-for-pending①">5.2. SyncManager interface</a> <a href="#ref-for-pending②">(2)</a>
-    <li><a href="#ref-for-pending③">5.3. The sync event</a> <a href="#ref-for-pending④">(2)</a> <a href="#ref-for-pending⑤">(3)</a> <a href="#ref-for-pending⑥">(4)</a> <a href="#ref-for-pending⑦">(5)</a>
+    <li><a href="#ref-for-pending①">6.2. SyncManager interface</a> <a href="#ref-for-pending②">(2)</a>
+    <li><a href="#ref-for-pending③">6.3. The sync event</a> <a href="#ref-for-pending④">(2)</a> <a href="#ref-for-pending⑤">(3)</a> <a href="#ref-for-pending⑥">(4)</a> <a href="#ref-for-pending⑦">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="waiting">
    <b><a href="#waiting">#waiting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-waiting">5.2. SyncManager interface</a>
-    <li><a href="#ref-for-waiting①">5.3. The sync event</a> <a href="#ref-for-waiting②">(2)</a>
+    <li><a href="#ref-for-waiting">6.2. SyncManager interface</a>
+    <li><a href="#ref-for-waiting①">6.3. The sync event</a> <a href="#ref-for-waiting②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="firing">
    <b><a href="#firing">#firing</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-firing">5.2. SyncManager interface</a>
-    <li><a href="#ref-for-firing①">5.3. The sync event</a> <a href="#ref-for-firing②">(2)</a>
+    <li><a href="#ref-for-firing">6.2. SyncManager interface</a>
+    <li><a href="#ref-for-firing①">6.3. The sync event</a> <a href="#ref-for-firing②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="reregisteredwhilefiring">
    <b><a href="#reregisteredwhilefiring">#reregisteredwhilefiring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-reregisteredwhilefiring">5.2. SyncManager interface</a>
-    <li><a href="#ref-for-reregisteredwhilefiring①">5.3. The sync event</a> <a href="#ref-for-reregisteredwhilefiring②">(2)</a>
+    <li><a href="#ref-for-reregisteredwhilefiring">6.2. SyncManager interface</a>
+    <li><a href="#ref-for-reregisteredwhilefiring①">6.3. The sync event</a> <a href="#ref-for-reregisteredwhilefiring②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="syncmanager">
    <b><a href="#syncmanager">#syncmanager</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-syncmanager">5.1. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-syncmanager①">(2)</a>
-    <li><a href="#ref-for-syncmanager②">5.2. SyncManager interface</a> <a href="#ref-for-syncmanager③">(2)</a> <a href="#ref-for-syncmanager④">(3)</a>
+    <li><a href="#ref-for-syncmanager">6.1. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-syncmanager①">(2)</a>
+    <li><a href="#ref-for-syncmanager②">6.2. SyncManager interface</a> <a href="#ref-for-syncmanager③">(2)</a> <a href="#ref-for-syncmanager④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-syncmanager-register">
    <b><a href="#dom-syncmanager-register">#dom-syncmanager-register</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-syncmanager-register">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-dom-syncmanager-register">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-syncmanager-gettags">
    <b><a href="#dom-syncmanager-gettags">#dom-syncmanager-gettags</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-syncmanager-gettags">5.2. SyncManager interface</a>
+    <li><a href="#ref-for-dom-syncmanager-gettags">6.2. SyncManager interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="syncevent">
    <b><a href="#syncevent">#syncevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-syncevent">5.3. The sync event</a> <a href="#ref-for-syncevent①">(2)</a> <a href="#ref-for-syncevent②">(3)</a>
+    <li><a href="#ref-for-syncevent">6.3. The sync event</a> <a href="#ref-for-syncevent①">(2)</a> <a href="#ref-for-syncevent②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-syncevent-tag">
    <b><a href="#dom-syncevent-tag">#dom-syncevent-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-syncevent-tag">5.3. The sync event</a>
+    <li><a href="#ref-for-dom-syncevent-tag">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-syncevent-lastchance">
    <b><a href="#dom-syncevent-lastchance">#dom-syncevent-lastchance</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-syncevent-lastchance">5.3. The sync event</a> <a href="#ref-for-dom-syncevent-lastchance①">(2)</a> <a href="#ref-for-dom-syncevent-lastchance②">(3)</a> <a href="#ref-for-dom-syncevent-lastchance③">(4)</a> <a href="#ref-for-dom-syncevent-lastchance④">(5)</a> <a href="#ref-for-dom-syncevent-lastchance⑤">(6)</a>
+    <li><a href="#ref-for-dom-syncevent-lastchance">6.3. The sync event</a> <a href="#ref-for-dom-syncevent-lastchance①">(2)</a> <a href="#ref-for-dom-syncevent-lastchance②">(3)</a> <a href="#ref-for-dom-syncevent-lastchance③">(4)</a> <a href="#ref-for-dom-syncevent-lastchance④">(5)</a> <a href="#ref-for-dom-syncevent-lastchance⑤">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-synceventinit">
    <b><a href="#dictdef-synceventinit">#dictdef-synceventinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-synceventinit">5.3. The sync event</a>
+    <li><a href="#ref-for-dictdef-synceventinit">6.3. The sync event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fire-a-sync-event">
    <b><a href="#fire-a-sync-event">#fire-a-sync-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fire-a-sync-event">5.2. SyncManager interface</a> <a href="#ref-for-fire-a-sync-event①">(2)</a>
-    <li><a href="#ref-for-fire-a-sync-event②">5.3. The sync event</a> <a href="#ref-for-fire-a-sync-event③">(2)</a> <a href="#ref-for-fire-a-sync-event④">(3)</a> <a href="#ref-for-fire-a-sync-event⑤">(4)</a>
+    <li><a href="#ref-for-fire-a-sync-event">6.2. SyncManager interface</a> <a href="#ref-for-fire-a-sync-event①">(2)</a>
+    <li><a href="#ref-for-fire-a-sync-event②">6.3. The sync event</a> <a href="#ref-for-fire-a-sync-event③">(2)</a> <a href="#ref-for-fire-a-sync-event④">(3)</a> <a href="#ref-for-fire-a-sync-event⑤">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="will-retry">
    <b><a href="#will-retry">#will-retry</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-will-retry">5.3. The sync event</a>
+    <li><a href="#ref-for-will-retry">6.3. The sync event</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
**edit: new PR over at https://github.com/WICG/background-sync/pull/183**

In https://github.com/w3c/permissions/issues/263, we're trying to move all the powerful features into the "parent" spec, rather than define a registry in the spec. That's what this PR does.

That said, if the intent is for background-sync to be [enabled by default](https://wicg.github.io/background-sync/spec/#permission) is it really a "[powerful feature](https://w3c.github.io/permissions/#dfn-powerful-feature)"? It doesn't seem to be the case that express permission is required for a UA to enable the API. 

(Currently Permissions claims it is, https://w3c.github.io/permissions/#background-sync)

Thoughts @mkruisselbrink @marcoscaceres?

See also https://github.com/w3c/permissions/issues/308.